### PR TITLE
feat(docs): update navigation links and enhance workflow permissions

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,5 +1,9 @@
 name: Documentation
 
+permissions:
+    contents: write
+
+
 on:
     push:
         branches:

--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -89,11 +89,11 @@ const config = {
                         items: [
                             {
                                 label: "Getting Started",
-                                to: "/docs/getting-started",
+                                to: "/docs/getting-started/overview",
                             },
                             {
                                 label: "API Reference",
-                                to: "docs/api",
+                                to: "/docs/api",
                             },
                         ],
                     },


### PR DESCRIPTION
Updates navigation links in Docusaurus configuration for improved routing, and adds `contents: write` permission in the documentation workflow to support better CI/CD operations.
This pull request includes updates to the documentation workflow and navigation structure. The most important changes involve granting write permissions to the documentation workflow and updating navigation links in the documentation configuration.

### Documentation workflow updates:
* [`.github/workflows/docs.yml`](diffhunk://#diff-9cf2000c53760d837a449f874e53f792819108d3a4bf346336d0f7d082deae2cR3-R6): Added `permissions` block with `contents: write` to enable write access for the documentation workflow.

### Navigation structure updates:
* [`docs/docusaurus.config.js`](diffhunk://#diff-28742c737e523f302e6de471b7fc27284dc8cf720be639e6afe4c17a550cd654L92-R96): Updated navigation links in the `config` object to adjust paths for "Getting Started" and "API Reference" sections. The "Getting Started" link now points to `/docs/getting-started/overview`, and the "API Reference" link now uses an absolute path `/docs/api`.