### PR TITLE
feat(docs): update Node.js version and fix build command in workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -23,13 +23,13 @@ jobs:
                     fetch-depth: 0
             -   uses: actions/setup-node@v4
                 with:
-                    node-version: 18
+                    node-version: 20
                     cache: npm
 
             -   name: Install dependencies
                 run: npm ci
             -   name: Build website
-                run: npm docs:build
+                run: npm run docs:build
 
             -   name: Upload Build Artifact
                 uses: actions/upload-pages-artifact@v3


### PR DESCRIPTION
Upgrades Node.js to version 20 in the documentation workflow for compatibility and improved performance. Corrects the build command to use `npm run docs:build` ensuring consistency with npm standards.