### PR TITLE
[Chore] Upgrade packages and fix docs links

### DIFF
--- a/docs/docs/examples/index.md
+++ b/docs/docs/examples/index.md
@@ -7,10 +7,10 @@ example includes complete setup instructions, configuration files, and working c
 
 ### 🌐 Web Applications
 
-- **[Web Webpack](./web-webpack)** - Browser applications using Webpack
+- **[Web Webpack](./examples/web-webpack)** - Browser applications using Webpack
 
 ### 🚀 Backend/CLI Applications
 
-- **[Node.js Webpack](./node-webpack)** - Server-side applications using Webpack
-- **[⚡Bun](./node-bun)** - High-performance applications using Bun runtime
+- **[Node.js Webpack](./examples/node-webpack)** - Server-side applications using Webpack
+- **[⚡Bun](./examples/node-bun)** - High-performance applications using Bun runtime
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,26 +12,26 @@
                 "json2toml": "^6.1.1",
                 "loader-utils": "^3.3.1",
                 "lodash": "^4.17.21",
-                "schema-utils": "^4.3.2",
+                "schema-utils": "^4.3.3",
                 "toml": "^3.0.0",
                 "wasm-pack": "^0.13.1",
-                "which": "^5.0.0"
+                "which": "^6.0.0"
             },
             "devDependencies": {
-                "@eslint/eslintrc": "^3.3.1",
-                "@eslint/js": "^9.30.1",
+                "@eslint/eslintrc": "^3.3.3",
+                "@eslint/js": "^9.39.2",
                 "@kesills/eslint-config-airbnb-typescript": "^20.0.0",
-                "@types/bun": "^1.2.18",
-                "@typescript-eslint/parser": "^8.35.1",
+                "@types/bun": "^1.3.4",
+                "@typescript-eslint/parser": "^8.49.0",
                 "eslint": "^8.57.1",
-                "eslint-config-prettier": "^9.1.0",
+                "eslint-config-prettier": "^9.1.2",
                 "eslint-plugin-import": "^2.32.0",
-                "eslint-plugin-prettier": "^5.5.1",
-                "globals": "^16.3.0",
-                "npm-check-updates": "^18.0.1",
-                "prettier": "^3.6.2",
+                "eslint-plugin-prettier": "^5.5.4",
+                "globals": "^16.5.0",
+                "npm-check-updates": "^19.2.0",
+                "prettier": "^3.7.4",
                 "prism-react-renderer": "^2.4.1",
-                "typescript": "^5.8.3"
+                "typescript": "^5.9.3"
             },
             "engines": {
                 "node": ">=20.0.0"
@@ -50,9 +50,9 @@
             }
         },
         "node_modules/@eslint-community/eslint-utils": {
-            "version": "4.7.0",
-            "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.7.0.tgz",
-            "integrity": "sha512-dyybb3AcajC7uha6CvhdVRJqaKyn7w2YKqKyAN37NKYgZT36w+iRb0Dymmc5qEJ549c/S31cMMSFd75bteCpCw==",
+            "version": "4.9.0",
+            "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.0.tgz",
+            "integrity": "sha512-ayVFHdtZ+hsq1t2Dy24wCmGXGe4q9Gu3smhLYALJrr473ZH27MsnSL+LKUlimp4BWJqMDMLmPpx/Q9R3OAlL4g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -82,9 +82,9 @@
             }
         },
         "node_modules/@eslint-community/regexpp": {
-            "version": "4.12.1",
-            "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.1.tgz",
-            "integrity": "sha512-CCZCDJuduB9OUkFkY2IgppNZMi2lBQgD2qzwXkEia16cge2pijY/aXi96CJMquDMn3nJdlPV1A5KrJEXwfLNzQ==",
+            "version": "4.12.2",
+            "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+            "integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -92,9 +92,9 @@
             }
         },
         "node_modules/@eslint/eslintrc": {
-            "version": "3.3.1",
-            "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.1.tgz",
-            "integrity": "sha512-gtF186CXhIl1p4pJNGZw8Yc6RlshoePRvE0X91oPGb3vZ8pM3qOS9W9NGPat9LziaBV7XrJWGylNQXkGcnM3IQ==",
+            "version": "3.3.3",
+            "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.3.tgz",
+            "integrity": "sha512-Kr+LPIUVKz2qkx1HAMH8q1q6azbqBAsXJUxBl/ODDuVPX45Z9DfwB8tPjTi6nNZ8BuM3nbJxC5zCAg5elnBUTQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -104,7 +104,7 @@
                 "globals": "^14.0.0",
                 "ignore": "^5.2.0",
                 "import-fresh": "^3.2.1",
-                "js-yaml": "^4.1.0",
+                "js-yaml": "^4.1.1",
                 "minimatch": "^3.1.2",
                 "strip-json-comments": "^3.1.1"
             },
@@ -129,9 +129,9 @@
             }
         },
         "node_modules/@eslint/js": {
-            "version": "9.30.1",
-            "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.30.1.tgz",
-            "integrity": "sha512-zXhuECFlyep42KZUhWjfvsmXGX39W8K8LFb8AWXM9gSV9dQB+MrJGLKvW6Zw0Ggnbpw0VHTtrhFXYe3Gym18jg==",
+            "version": "9.39.2",
+            "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.2.tgz",
+            "integrity": "sha512-q1mjIoW1VX4IvSocvM/vbTiveKC4k9eLrajNEuSsmjymSDEbpGddtpfOoN7YGAqBK3NG+uqo8ia4PDTt8buCYA==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -242,9 +242,9 @@
             }
         },
         "node_modules/@pkgr/core": {
-            "version": "0.2.7",
-            "resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.2.7.tgz",
-            "integrity": "sha512-YLT9Zo3oNPJoBjBc4q8G2mjU4tqIbf5CEOORbUUr48dCD9q3umJ3IPlVqOqDakPfd2HuwccBaqlGhN4Gmr5OWg==",
+            "version": "0.2.9",
+            "resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.2.9.tgz",
+            "integrity": "sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -283,13 +283,13 @@
             }
         },
         "node_modules/@types/bun": {
-            "version": "1.2.18",
-            "resolved": "https://registry.npmjs.org/@types/bun/-/bun-1.2.18.tgz",
-            "integrity": "sha512-Xf6RaWVheyemaThV0kUfaAUvCNokFr+bH8Jxp+tTZfx7dAPA8z9ePnP9S9+Vspzuxxx9JRAXhnyccRj3GyCMdQ==",
+            "version": "1.3.4",
+            "resolved": "https://registry.npmjs.org/@types/bun/-/bun-1.3.4.tgz",
+            "integrity": "sha512-EEPTKXHP+zKGPkhRLv+HI0UEX8/o+65hqARxLy8Ov5rIxMBPNTjeZww00CIihrIQGEQBYg+0roO5qOnS/7boGA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "bun-types": "1.2.18"
+                "bun-types": "1.3.4"
             }
         },
         "node_modules/@types/json-schema": {
@@ -306,13 +306,13 @@
             "license": "MIT"
         },
         "node_modules/@types/node": {
-            "version": "24.0.13",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-24.0.13.tgz",
-            "integrity": "sha512-Qm9OYVOFHFYg3wJoTSrz80hoec5Lia/dPp84do3X7dZvLikQvM1YpmvTBEdIr/e+U8HTkFjLHLnl78K/qjf+jQ==",
+            "version": "25.0.2",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-25.0.2.tgz",
+            "integrity": "sha512-gWEkeiyYE4vqjON/+Obqcoeffmk0NF15WSBwSs7zwVA2bAbTaE0SJ7P0WNGoJn8uE7fiaV5a7dKYIJriEqOrmA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "undici-types": "~7.8.0"
+                "undici-types": "~7.16.0"
             }
         },
         "node_modules/@types/prismjs": {
@@ -322,31 +322,19 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/@types/react": {
-            "version": "19.1.8",
-            "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.8.tgz",
-            "integrity": "sha512-AwAfQ2Wa5bCx9WP8nZL2uMZWod7J7/JSplxbTmBQ5ms6QpqNYm672H0Vu9ZVKVngQ+ii4R/byguVEUZQyeg44g==",
-            "dev": true,
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "csstype": "^3.0.2"
-            }
-        },
         "node_modules/@typescript-eslint/eslint-plugin": {
-            "version": "8.36.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.36.0.tgz",
-            "integrity": "sha512-lZNihHUVB6ZZiPBNgOQGSxUASI7UJWhT8nHyUGCnaQ28XFCw98IfrMCG3rUl1uwUWoAvodJQby2KTs79UTcrAg==",
+            "version": "8.49.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.49.0.tgz",
+            "integrity": "sha512-JXij0vzIaTtCwu6SxTh8qBc66kmf1xs7pI4UOiMDFVct6q86G0Zs7KRcEoJgY3Cav3x5Tq0MF5jwgpgLqgKG3A==",
             "dev": true,
             "license": "MIT",
             "peer": true,
             "dependencies": {
                 "@eslint-community/regexpp": "^4.10.0",
-                "@typescript-eslint/scope-manager": "8.36.0",
-                "@typescript-eslint/type-utils": "8.36.0",
-                "@typescript-eslint/utils": "8.36.0",
-                "@typescript-eslint/visitor-keys": "8.36.0",
-                "graphemer": "^1.4.0",
+                "@typescript-eslint/scope-manager": "8.49.0",
+                "@typescript-eslint/type-utils": "8.49.0",
+                "@typescript-eslint/utils": "8.49.0",
+                "@typescript-eslint/visitor-keys": "8.49.0",
                 "ignore": "^7.0.0",
                 "natural-compare": "^1.4.0",
                 "ts-api-utils": "^2.1.0"
@@ -359,9 +347,9 @@
                 "url": "https://opencollective.com/typescript-eslint"
             },
             "peerDependencies": {
-                "@typescript-eslint/parser": "^8.36.0",
+                "@typescript-eslint/parser": "^8.49.0",
                 "eslint": "^8.57.0 || ^9.0.0",
-                "typescript": ">=4.8.4 <5.9.0"
+                "typescript": ">=4.8.4 <6.0.0"
             }
         },
         "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
@@ -376,16 +364,16 @@
             }
         },
         "node_modules/@typescript-eslint/parser": {
-            "version": "8.36.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.36.0.tgz",
-            "integrity": "sha512-FuYgkHwZLuPbZjQHzJXrtXreJdFMKl16BFYyRrLxDhWr6Qr7Kbcu2s1Yhu8tsiMXw1S0W1pjfFfYEt+R604s+Q==",
+            "version": "8.49.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.49.0.tgz",
+            "integrity": "sha512-N9lBGA9o9aqb1hVMc9hzySbhKibHmB+N3IpoShyV6HyQYRGIhlrO5rQgttypi+yEeKsKI4idxC8Jw6gXKD4THA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/scope-manager": "8.36.0",
-                "@typescript-eslint/types": "8.36.0",
-                "@typescript-eslint/typescript-estree": "8.36.0",
-                "@typescript-eslint/visitor-keys": "8.36.0",
+                "@typescript-eslint/scope-manager": "8.49.0",
+                "@typescript-eslint/types": "8.49.0",
+                "@typescript-eslint/typescript-estree": "8.49.0",
+                "@typescript-eslint/visitor-keys": "8.49.0",
                 "debug": "^4.3.4"
             },
             "engines": {
@@ -397,18 +385,18 @@
             },
             "peerDependencies": {
                 "eslint": "^8.57.0 || ^9.0.0",
-                "typescript": ">=4.8.4 <5.9.0"
+                "typescript": ">=4.8.4 <6.0.0"
             }
         },
         "node_modules/@typescript-eslint/project-service": {
-            "version": "8.36.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.36.0.tgz",
-            "integrity": "sha512-JAhQFIABkWccQYeLMrHadu/fhpzmSQ1F1KXkpzqiVxA/iYI6UnRt2trqXHt1sYEcw1mxLnB9rKMsOxXPxowN/g==",
+            "version": "8.49.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.49.0.tgz",
+            "integrity": "sha512-/wJN0/DKkmRUMXjZUXYZpD1NEQzQAAn9QWfGwo+Ai8gnzqH7tvqS7oNVdTjKqOcPyVIdZdyCMoqN66Ia789e7g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/tsconfig-utils": "^8.36.0",
-                "@typescript-eslint/types": "^8.36.0",
+                "@typescript-eslint/tsconfig-utils": "^8.49.0",
+                "@typescript-eslint/types": "^8.49.0",
                 "debug": "^4.3.4"
             },
             "engines": {
@@ -419,18 +407,18 @@
                 "url": "https://opencollective.com/typescript-eslint"
             },
             "peerDependencies": {
-                "typescript": ">=4.8.4 <5.9.0"
+                "typescript": ">=4.8.4 <6.0.0"
             }
         },
         "node_modules/@typescript-eslint/scope-manager": {
-            "version": "8.36.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.36.0.tgz",
-            "integrity": "sha512-wCnapIKnDkN62fYtTGv2+RY8FlnBYA3tNm0fm91kc2BjPhV2vIjwwozJ7LToaLAyb1ca8BxrS7vT+Pvvf7RvqA==",
+            "version": "8.49.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.49.0.tgz",
+            "integrity": "sha512-npgS3zi+/30KSOkXNs0LQXtsg9ekZ8OISAOLGWA/ZOEn0ZH74Ginfl7foziV8DT+D98WfQ5Kopwqb/PZOaIJGg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "8.36.0",
-                "@typescript-eslint/visitor-keys": "8.36.0"
+                "@typescript-eslint/types": "8.49.0",
+                "@typescript-eslint/visitor-keys": "8.49.0"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -441,9 +429,9 @@
             }
         },
         "node_modules/@typescript-eslint/tsconfig-utils": {
-            "version": "8.36.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.36.0.tgz",
-            "integrity": "sha512-Nhh3TIEgN18mNbdXpd5Q8mSCBnrZQeY9V7Ca3dqYvNDStNIGRmJA6dmrIPMJ0kow3C7gcQbpsG2rPzy1Ks/AnA==",
+            "version": "8.49.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.49.0.tgz",
+            "integrity": "sha512-8prixNi1/6nawsRYxet4YOhnbW+W9FK/bQPxsGB1D3ZrDzbJ5FXw5XmzxZv82X3B+ZccuSxo/X8q9nQ+mFecWA==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -454,19 +442,20 @@
                 "url": "https://opencollective.com/typescript-eslint"
             },
             "peerDependencies": {
-                "typescript": ">=4.8.4 <5.9.0"
+                "typescript": ">=4.8.4 <6.0.0"
             }
         },
         "node_modules/@typescript-eslint/type-utils": {
-            "version": "8.36.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.36.0.tgz",
-            "integrity": "sha512-5aaGYG8cVDd6cxfk/ynpYzxBRZJk7w/ymto6uiyUFtdCozQIsQWh7M28/6r57Fwkbweng8qAzoMCPwSJfWlmsg==",
+            "version": "8.49.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.49.0.tgz",
+            "integrity": "sha512-KTExJfQ+svY8I10P4HdxKzWsvtVnsuCifU5MvXrRwoP2KOlNZ9ADNEWWsQTJgMxLzS5VLQKDjkCT/YzgsnqmZg==",
             "dev": true,
             "license": "MIT",
             "peer": true,
             "dependencies": {
-                "@typescript-eslint/typescript-estree": "8.36.0",
-                "@typescript-eslint/utils": "8.36.0",
+                "@typescript-eslint/types": "8.49.0",
+                "@typescript-eslint/typescript-estree": "8.49.0",
+                "@typescript-eslint/utils": "8.49.0",
                 "debug": "^4.3.4",
                 "ts-api-utils": "^2.1.0"
             },
@@ -479,13 +468,13 @@
             },
             "peerDependencies": {
                 "eslint": "^8.57.0 || ^9.0.0",
-                "typescript": ">=4.8.4 <5.9.0"
+                "typescript": ">=4.8.4 <6.0.0"
             }
         },
         "node_modules/@typescript-eslint/types": {
-            "version": "8.36.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.36.0.tgz",
-            "integrity": "sha512-xGms6l5cTJKQPZOKM75Dl9yBfNdGeLRsIyufewnxT4vZTrjC0ImQT4fj8QmtJK84F58uSh5HVBSANwcfiXxABQ==",
+            "version": "8.49.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.49.0.tgz",
+            "integrity": "sha512-e9k/fneezorUo6WShlQpMxXh8/8wfyc+biu6tnAqA81oWrEic0k21RHzP9uqqpyBBeBKu4T+Bsjy9/b8u7obXQ==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -497,21 +486,20 @@
             }
         },
         "node_modules/@typescript-eslint/typescript-estree": {
-            "version": "8.36.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.36.0.tgz",
-            "integrity": "sha512-JaS8bDVrfVJX4av0jLpe4ye0BpAaUW7+tnS4Y4ETa3q7NoZgzYbN9zDQTJ8kPb5fQ4n0hliAt9tA4Pfs2zA2Hg==",
+            "version": "8.49.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.49.0.tgz",
+            "integrity": "sha512-jrLdRuAbPfPIdYNppHJ/D0wN+wwNfJ32YTAm10eJVsFmrVpXQnDWBn8niCSMlWjvml8jsce5E/O+86IQtTbJWA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/project-service": "8.36.0",
-                "@typescript-eslint/tsconfig-utils": "8.36.0",
-                "@typescript-eslint/types": "8.36.0",
-                "@typescript-eslint/visitor-keys": "8.36.0",
+                "@typescript-eslint/project-service": "8.49.0",
+                "@typescript-eslint/tsconfig-utils": "8.49.0",
+                "@typescript-eslint/types": "8.49.0",
+                "@typescript-eslint/visitor-keys": "8.49.0",
                 "debug": "^4.3.4",
-                "fast-glob": "^3.3.2",
-                "is-glob": "^4.0.3",
                 "minimatch": "^9.0.4",
                 "semver": "^7.6.0",
+                "tinyglobby": "^0.2.15",
                 "ts-api-utils": "^2.1.0"
             },
             "engines": {
@@ -522,7 +510,7 @@
                 "url": "https://opencollective.com/typescript-eslint"
             },
             "peerDependencies": {
-                "typescript": ">=4.8.4 <5.9.0"
+                "typescript": ">=4.8.4 <6.0.0"
             }
         },
         "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
@@ -552,17 +540,17 @@
             }
         },
         "node_modules/@typescript-eslint/utils": {
-            "version": "8.36.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.36.0.tgz",
-            "integrity": "sha512-VOqmHu42aEMT+P2qYjylw6zP/3E/HvptRwdn/PZxyV27KhZg2IOszXod4NcXisWzPAGSS4trE/g4moNj6XmH2g==",
+            "version": "8.49.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.49.0.tgz",
+            "integrity": "sha512-N3W7rJw7Rw+z1tRsHZbK395TWSYvufBXumYtEGzypgMUthlg0/hmCImeA8hgO2d2G4pd7ftpxxul2J8OdtdaFA==",
             "dev": true,
             "license": "MIT",
             "peer": true,
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.7.0",
-                "@typescript-eslint/scope-manager": "8.36.0",
-                "@typescript-eslint/types": "8.36.0",
-                "@typescript-eslint/typescript-estree": "8.36.0"
+                "@typescript-eslint/scope-manager": "8.49.0",
+                "@typescript-eslint/types": "8.49.0",
+                "@typescript-eslint/typescript-estree": "8.49.0"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -573,17 +561,17 @@
             },
             "peerDependencies": {
                 "eslint": "^8.57.0 || ^9.0.0",
-                "typescript": ">=4.8.4 <5.9.0"
+                "typescript": ">=4.8.4 <6.0.0"
             }
         },
         "node_modules/@typescript-eslint/visitor-keys": {
-            "version": "8.36.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.36.0.tgz",
-            "integrity": "sha512-vZrhV2lRPWDuGoxcmrzRZyxAggPL+qp3WzUrlZD+slFueDiYHxeBa34dUXPuC0RmGKzl4lS5kFJYvKCq9cnNDA==",
+            "version": "8.49.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.49.0.tgz",
+            "integrity": "sha512-LlKaciDe3GmZFphXIc79THF/YYBugZ7FS1pO581E/edlVVNbZKDy93evqmrfQ9/Y4uN0vVhX4iuchq26mK/iiA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "8.36.0",
+                "@typescript-eslint/types": "8.49.0",
                 "eslint-visitor-keys": "^4.2.1"
             },
             "engines": {
@@ -877,9 +865,10 @@
             "license": "MIT"
         },
         "node_modules/binary-install": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/binary-install/-/binary-install-1.1.0.tgz",
-            "integrity": "sha512-rkwNGW+3aQVSZoD0/o3mfPN6Yxh3Id0R/xzTVBVVpGNlVz8EGwusksxRlbk/A5iKTZt9zkMn3qIqmAt3vpfbzg==",
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/binary-install/-/binary-install-1.1.2.tgz",
+            "integrity": "sha512-ZS2cqFHPZOy4wLxvzqfQvDjCOifn+7uCPqNmYRIBM/03+yllON+4fNnsD0VJdW0p97y+E+dTRNPStWNqMBq+9g==",
+            "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
             "license": "MIT",
             "dependencies": {
                 "axios": "^0.26.1",
@@ -900,30 +889,14 @@
                 "concat-map": "0.0.1"
             }
         },
-        "node_modules/braces": {
-            "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
-            "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "fill-range": "^7.1.1"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
         "node_modules/bun-types": {
-            "version": "1.2.18",
-            "resolved": "https://registry.npmjs.org/bun-types/-/bun-types-1.2.18.tgz",
-            "integrity": "sha512-04+Eha5NP7Z0A9YgDAzMk5PHR16ZuLVa83b26kH5+cp1qZW4F6FmAURngE7INf4tKOvCE69vYvDEwoNl1tGiWw==",
+            "version": "1.3.4",
+            "resolved": "https://registry.npmjs.org/bun-types/-/bun-types-1.3.4.tgz",
+            "integrity": "sha512-5ua817+BZPZOlNaRgGBpZJOSAQ9RQ17pkwPD0yR7CfJg+r8DgIILByFifDTa+IPDDxzf5VNhtNlcKqFzDgJvlQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@types/node": "*"
-            },
-            "peerDependencies": {
-                "@types/react": "^19"
             }
         },
         "node_modules/call-bind": {
@@ -1094,14 +1067,6 @@
                 "node": ">= 8"
             }
         },
-        "node_modules/csstype": {
-            "version": "3.1.3",
-            "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
-            "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-            "dev": true,
-            "license": "MIT",
-            "peer": true
-        },
         "node_modules/data-view-buffer": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/data-view-buffer/-/data-view-buffer-1.0.2.tgz",
@@ -1157,9 +1122,9 @@
             }
         },
         "node_modules/debug": {
-            "version": "4.4.1",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
-            "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+            "version": "4.4.3",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+            "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -1246,9 +1211,9 @@
             }
         },
         "node_modules/es-abstract": {
-            "version": "1.24.0",
-            "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.24.0.tgz",
-            "integrity": "sha512-WSzPgsdLtTcQwm4CROfS5ju2Wa1QQcVeT37jFjYzdFz1r9ahadC8B8/a4qxJxM+09F18iumCdRmlr96ZYkQvEg==",
+            "version": "1.24.1",
+            "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.24.1.tgz",
+            "integrity": "sha512-zHXBLhP+QehSSbsS9Pt23Gg964240DPd6QCf8WpkqEXxQ7fhdZzYsocOr5u7apWonsS5EjZDmTF+/slGMyasvw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -1497,9 +1462,9 @@
             }
         },
         "node_modules/eslint-config-prettier": {
-            "version": "9.1.0",
-            "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-9.1.0.tgz",
-            "integrity": "sha512-NSWl5BFQWEPi1j4TjVNItzYV7dZXZ+wP6I6ZhrBGpChQhZRUaElihE9uRRkcbRnNb76UMKDF3r+WTmNcGPKsqw==",
+            "version": "9.1.2",
+            "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-9.1.2.tgz",
+            "integrity": "sha512-iI1f+D2ViGn+uvv5HuHVUamg8ll4tN+JRHGc6IJi4TP9Kl976C57fzPXgseXNs8v0iA8aSJpHsTWjDb9QJamGQ==",
             "dev": true,
             "license": "MIT",
             "bin": {
@@ -1627,9 +1592,9 @@
             }
         },
         "node_modules/eslint-plugin-prettier": {
-            "version": "5.5.1",
-            "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-5.5.1.tgz",
-            "integrity": "sha512-dobTkHT6XaEVOo8IO90Q4DOSxnm3Y151QxPJlM/vKC0bVy+d6cVWQZLlFiuZPP0wS6vZwSKeJgKkcS+KfMBlRw==",
+            "version": "5.5.4",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-5.5.4.tgz",
+            "integrity": "sha512-swNtI95SToIz05YINMA6Ox5R057IMAmWZ26GqPxusAp1TZzj+IdY9tXNWWD3vkF/wEqydCONcwjTFpxybBqZsg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -1845,36 +1810,6 @@
             "dev": true,
             "license": "Apache-2.0"
         },
-        "node_modules/fast-glob": {
-            "version": "3.3.3",
-            "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
-            "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "@nodelib/fs.stat": "^2.0.2",
-                "@nodelib/fs.walk": "^1.2.3",
-                "glob-parent": "^5.1.2",
-                "merge2": "^1.3.0",
-                "micromatch": "^4.0.8"
-            },
-            "engines": {
-                "node": ">=8.6.0"
-            }
-        },
-        "node_modules/fast-glob/node_modules/glob-parent": {
-            "version": "5.1.2",
-            "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-            "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-            "dev": true,
-            "license": "ISC",
-            "dependencies": {
-                "is-glob": "^4.0.1"
-            },
-            "engines": {
-                "node": ">= 6"
-            }
-        },
         "node_modules/fast-json-stable-stringify": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
@@ -1890,9 +1825,9 @@
             "license": "MIT"
         },
         "node_modules/fast-uri": {
-            "version": "3.0.6",
-            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.0.6.tgz",
-            "integrity": "sha512-Atfo14OibSv5wAp4VWNsFYE1AchQRTv9cBGWET4pZWHzYshFSS9NQI6I57rdKn9croWVMbYFbLhJ+yJvmZIIHw==",
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+            "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
             "funding": [
                 {
                     "type": "github",
@@ -1915,6 +1850,24 @@
                 "reusify": "^1.0.4"
             }
         },
+        "node_modules/fdir": {
+            "version": "6.5.0",
+            "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+            "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12.0.0"
+            },
+            "peerDependencies": {
+                "picomatch": "^3 || ^4"
+            },
+            "peerDependenciesMeta": {
+                "picomatch": {
+                    "optional": true
+                }
+            }
+        },
         "node_modules/file-entry-cache": {
             "version": "6.0.1",
             "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
@@ -1926,19 +1879,6 @@
             },
             "engines": {
                 "node": "^10.12.0 || >=12.0.0"
-            }
-        },
-        "node_modules/fill-range": {
-            "version": "7.1.1",
-            "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
-            "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "to-regex-range": "^5.0.1"
-            },
-            "engines": {
-                "node": ">=8"
             }
         },
         "node_modules/find-up": {
@@ -1981,9 +1921,9 @@
             "license": "ISC"
         },
         "node_modules/follow-redirects": {
-            "version": "1.15.9",
-            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
-            "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
+            "version": "1.15.11",
+            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
+            "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
             "funding": [
                 {
                     "type": "individual",
@@ -2087,6 +2027,16 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/generator-function": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/generator-function/-/generator-function-2.0.1.tgz",
+            "integrity": "sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            }
+        },
         "node_modules/get-intrinsic": {
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
@@ -2179,9 +2129,9 @@
             }
         },
         "node_modules/globals": {
-            "version": "16.3.0",
-            "resolved": "https://registry.npmjs.org/globals/-/globals-16.3.0.tgz",
-            "integrity": "sha512-bqWEnJ1Nt3neqx2q5SFfGS8r/ahumIakg3HcwtNlrVlwXIeNumWn/c7Pn/wKzGhf6SaW6H6uWXLqC30STCMchQ==",
+            "version": "16.5.0",
+            "resolved": "https://registry.npmjs.org/globals/-/globals-16.5.0.tgz",
+            "integrity": "sha512-c/c15i26VrJ4IRt5Z89DnIzCGDn9EcebibhAOjw5ibqEHsE1wLUgkPn9RDmNcUKyU87GeaL633nyJ+pplFR2ZQ==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -2553,14 +2503,15 @@
             }
         },
         "node_modules/is-generator-function": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.0.tgz",
-            "integrity": "sha512-nPUB5km40q9e8UfN/Zc24eLlzdSf9OfKByBw9CIdw4H1giPMeA0OIJvbchsCu4npfI2QcMVBsGEBHKZ7wLTWmQ==",
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.2.tgz",
+            "integrity": "sha512-upqt1SkGkODW9tsGNG5mtXTXtECizwtS2kA161M+gJPc1xdb/Ax629af6YrTwcOeQHbewrPNlE5Dx7kzvXTizA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "call-bound": "^1.0.3",
-                "get-proto": "^1.0.0",
+                "call-bound": "^1.0.4",
+                "generator-function": "^2.0.0",
+                "get-proto": "^1.0.1",
                 "has-tostringtag": "^1.0.2",
                 "safe-regex-test": "^1.1.0"
             },
@@ -2608,16 +2559,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/is-number": {
-            "version": "7.0.0",
-            "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-            "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.12.0"
             }
         },
         "node_modules/is-number-object": {
@@ -2809,9 +2750,9 @@
             }
         },
         "node_modules/js-yaml": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-            "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+            "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -2960,43 +2901,6 @@
                 "node": ">= 0.4"
             }
         },
-        "node_modules/merge2": {
-            "version": "1.4.1",
-            "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
-            "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 8"
-            }
-        },
-        "node_modules/micromatch": {
-            "version": "4.0.8",
-            "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
-            "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "braces": "^3.0.3",
-                "picomatch": "^2.3.1"
-            },
-            "engines": {
-                "node": ">=8.6"
-            }
-        },
-        "node_modules/micromatch/node_modules/picomatch": {
-            "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-            "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">=8.6"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/jonschlinkert"
-            }
-        },
         "node_modules/minimatch": {
             "version": "3.1.2",
             "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -3080,9 +2984,9 @@
             "license": "MIT"
         },
         "node_modules/npm-check-updates": {
-            "version": "18.0.1",
-            "resolved": "https://registry.npmjs.org/npm-check-updates/-/npm-check-updates-18.0.1.tgz",
-            "integrity": "sha512-MO7mLp/8nm6kZNLLyPgz4gHmr9tLoU+pWPLdXuGAx+oZydBHkHWN0ibTonsrfwC2WEQNIQxuZagYwB67JQpAuw==",
+            "version": "19.2.0",
+            "resolved": "https://registry.npmjs.org/npm-check-updates/-/npm-check-updates-19.2.0.tgz",
+            "integrity": "sha512-XSIuL0FNgzXPDZa4lje7+OwHjiyEt84qQm6QMsQRbixNY5EHEM9nhgOjxjlK9jIbN+ysvSqOV8DKNS0zydwbdg==",
             "dev": true,
             "license": "Apache-2.0",
             "bin": {
@@ -3090,7 +2994,7 @@
                 "npm-check-updates": "build/cli.js"
             },
             "engines": {
-                "node": "^18.18.0 || >=20.0.0",
+                "node": ">=20.0.0",
                 "npm": ">=8.12.1"
             }
         },
@@ -3335,12 +3239,11 @@
             "license": "MIT"
         },
         "node_modules/picomatch": {
-            "version": "4.0.2",
-            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
-            "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
+            "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+            "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=12"
             },
@@ -3369,9 +3272,9 @@
             }
         },
         "node_modules/prettier": {
-            "version": "3.6.2",
-            "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.6.2.tgz",
-            "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
+            "version": "3.7.4",
+            "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.7.4.tgz",
+            "integrity": "sha512-v6UNi1+3hSlVvv8fSaoUbggEM5VErKmmpGA7Pl3HF8V6uKY7rvClBOJlH6yNwQtfTueNkGVpOv/mtWL9L4bgRA==",
             "dev": true,
             "license": "MIT",
             "bin": {
@@ -3443,9 +3346,9 @@
             "license": "MIT"
         },
         "node_modules/react": {
-            "version": "19.1.0",
-            "resolved": "https://registry.npmjs.org/react/-/react-19.1.0.tgz",
-            "integrity": "sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==",
+            "version": "19.2.3",
+            "resolved": "https://registry.npmjs.org/react/-/react-19.2.3.tgz",
+            "integrity": "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==",
             "dev": true,
             "license": "MIT",
             "peer": true,
@@ -3507,13 +3410,13 @@
             }
         },
         "node_modules/resolve": {
-            "version": "1.22.10",
-            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.10.tgz",
-            "integrity": "sha512-NPRy+/ncIMeDlTAsuqwKIiferiawhefFJtkNSW0qZJEqMEb+qBt/77B/jGeeek+F0uOeN05CDa6HXbbIgtVX4w==",
+            "version": "1.22.11",
+            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.11.tgz",
+            "integrity": "sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "is-core-module": "^2.16.0",
+                "is-core-module": "^2.16.1",
                 "path-parse": "^1.0.7",
                 "supports-preserve-symlinks-flag": "^1.0.0"
             },
@@ -3644,9 +3547,9 @@
             }
         },
         "node_modules/schema-utils": {
-            "version": "4.3.2",
-            "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.2.tgz",
-            "integrity": "sha512-Gn/JaSk/Mt9gYubxTtSn/QCV4em9mpAPiR1rqy/Ocu19u/G9J5WWdNoUT4SiV6mFC3y6cxyFcFwdzPM3FgxGAQ==",
+            "version": "4.3.3",
+            "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.3.3.tgz",
+            "integrity": "sha512-eflK8wEtyOE6+hsaRVPxvUKYCpRgzLqDTb8krvAsRIwOGlHoSgYLgBXoubGgLd2fT41/OUYdb48v4k4WWHQurA==",
             "license": "MIT",
             "dependencies": {
                 "@types/json-schema": "^7.0.9",
@@ -3697,9 +3600,9 @@
             "license": "MIT"
         },
         "node_modules/semver": {
-            "version": "7.7.2",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
-            "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+            "version": "7.7.3",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
+            "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
             "dev": true,
             "license": "ISC",
             "bin": {
@@ -4002,13 +3905,13 @@
             }
         },
         "node_modules/synckit": {
-            "version": "0.11.8",
-            "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.11.8.tgz",
-            "integrity": "sha512-+XZ+r1XGIJGeQk3VvXhT6xx/VpbHsRzsTkGgF6E5RX9TTXD0118l87puaEBZ566FhqblC6U0d4XnubznJDm30A==",
+            "version": "0.11.11",
+            "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.11.11.tgz",
+            "integrity": "sha512-MeQTA1r0litLUf0Rp/iisCaL8761lKAZHaimlbGK4j0HysC4PLfqygQj9srcs0m2RdtDYnF8UuYyKpbjHYp7Jw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@pkgr/core": "^0.2.4"
+                "@pkgr/core": "^0.2.9"
             },
             "engines": {
                 "node": "^14.18.0 || >=16.0.0"
@@ -4041,17 +3944,21 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/to-regex-range": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
-            "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+        "node_modules/tinyglobby": {
+            "version": "0.2.15",
+            "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
+            "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "is-number": "^7.0.0"
+                "fdir": "^6.5.0",
+                "picomatch": "^4.0.3"
             },
             "engines": {
-                "node": ">=8.0"
+                "node": ">=12.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/SuperchupuDev"
             }
         },
         "node_modules/toml": {
@@ -4191,9 +4098,9 @@
             }
         },
         "node_modules/typescript": {
-            "version": "5.8.3",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
-            "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
+            "version": "5.9.3",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+            "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
             "dev": true,
             "license": "Apache-2.0",
             "bin": {
@@ -4224,9 +4131,9 @@
             }
         },
         "node_modules/undici-types": {
-            "version": "7.8.0",
-            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.8.0.tgz",
-            "integrity": "sha512-9UJ2xGDvQ43tYyVMpuHlsgApydB8ZKfVYTsLDhXkFL/6gfkp+U8xTGdh8pMJv1SpZna0zxG1DwsKZsreLbXBxw==",
+            "version": "7.16.0",
+            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+            "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
             "dev": true,
             "license": "MIT"
         },
@@ -4254,9 +4161,9 @@
             }
         },
         "node_modules/which": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/which/-/which-5.0.0.tgz",
-            "integrity": "sha512-JEdGzHwwkrbWoGOlIHqQ5gtprKGOenpDHpxE9zVR1bWbOtYRyPPHMe9FaP6x61CmNaTThSkb0DAJte5jD+DmzQ==",
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/which/-/which-6.0.0.tgz",
+            "integrity": "sha512-f+gEpIKMR9faW/JgAgPK1D7mekkFoqbmiwvNzuhsHetni20QSgzg9Vhn0g2JSJkkfehQnqdUAx7/e15qS1lPxg==",
             "license": "ISC",
             "dependencies": {
                 "isexe": "^3.1.1"
@@ -4265,7 +4172,7 @@
                 "node-which": "bin/which.js"
             },
             "engines": {
-                "node": "^18.17.0 || >=20.5.0"
+                "node": "^20.17.0 || >=22.9.0"
             }
         },
         "node_modules/which-boxed-primitive": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
         "docs:swizzle": "docusaurus swizzle --config ./docs/docusaurus.config.js",
         "docs:deploy": "docusaurus deploy --config ./docs/docusaurus.config.js",
         "docs:clear": "docusaurus clear --config ./docs/docusaurus.config.js",
-        "docs:serve": "docusaurus serve --config ./docs/docusaurus.config.js"
+        "docs:serve": "docusaurus serve --config ./docs/docusaurus.config.js",
+        "updates": "npm-check-updates"
     },
     "repository": {
         "type": "git",
@@ -93,10 +94,10 @@
         "json2toml": "^6.1.1",
         "loader-utils": "^3.3.1",
         "lodash": "^4.17.21",
-        "schema-utils": "^4.3.2",
+        "schema-utils": "^4.3.3",
         "toml": "^3.0.0",
         "wasm-pack": "^0.13.1",
-        "which": "^5.0.0"
+        "which": "^6.0.0"
     },
     "peerDependencies": {
         "bun": "1.x.x",
@@ -111,26 +112,26 @@
         }
     },
     "devDependencies": {
-        "@eslint/eslintrc": "^3.3.1",
-        "@eslint/js": "^9.30.1",
+        "@eslint/eslintrc": "^3.3.3",
+        "@eslint/js": "^9.39.2",
         "@kesills/eslint-config-airbnb-typescript": "^20.0.0",
-        "@types/bun": "^1.2.18",
-        "@typescript-eslint/parser": "^8.35.1",
+        "@types/bun": "^1.3.4",
+        "@typescript-eslint/parser": "^8.49.0",
         "eslint": "^8.57.1",
-        "eslint-config-prettier": "^9.1.0",
+        "eslint-config-prettier": "^9.1.2",
         "eslint-plugin-import": "^2.32.0",
-        "eslint-plugin-prettier": "^5.5.1",
-        "globals": "^16.3.0",
-        "npm-check-updates": "^18.0.1",
-        "prettier": "^3.6.2",
+        "eslint-plugin-prettier": "^5.5.4",
+        "globals": "^16.5.0",
+        "npm-check-updates": "^19.2.0",
+        "prettier": "^3.7.4",
         "prism-react-renderer": "^2.4.1",
-        "typescript": "^5.8.3"
+        "typescript": "^5.9.3"
     },
     "engines": {
         "node": ">=20.0.0"
     },
     "volta": {
-        "node": "20.19.3",
+        "node": "22.21.1",
         "npm": "11.4.2"
     },
     "files": [


### PR DESCRIPTION
This pull request updates project dependencies to their latest versions and improves documentation links for example projects. It also adds a new script for checking package updates.

Dependency updates:

* Updated several dependencies and devDependencies in `package.json` to their latest versions, including `schema-utils`, `which`, ESLint packages, `@types/bun`, `npm-check-updates`, `prettier`, `globals`, and `typescript`. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L96-R100) [[2]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L114-R134)
* Updated the required Node.js version in the Volta configuration from `20.19.3` to `22.21.1` in `package.json`.

Tooling improvements:

* Added a new `updates` script to `package.json` for running `npm-check-updates` to help keep dependencies up to date.

Documentation improvements:

* Fixed and clarified example project links in `docs/docs/examples/index.md` to point to the correct subdirectories under `examples/`.