### PR TITLE
[RL-59] upgrade wasm-pack to 0.15 and raise the rust floor to 1.88

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
             matrix:
                 os: [ ubuntu-latest, ubuntu-24.04-arm, windows-latest, macos-latest ]
                 node: [ 22, 24 ]
-                rust: [ "1.88.0", "1.87.0", "1.86.0", "1.85.1" ]
+                rust: [ "1.88.0", "1.93.0" ]
                 test: [ example/node-bun, example/node-webpack ]
         steps:
             -   uses: actions/checkout@v5

--- a/docs/docs/getting-started/installation.mdx
+++ b/docs/docs/getting-started/installation.mdx
@@ -14,12 +14,13 @@ Need help with prerequisites? Check our [Prerequisites Guide](./prerequisites) f
 ## Package Installation
 ### Version Compatibility
 
-| rust-wasmpack-loader | Webpack-node | Webpack-web | Bun   | Node.js  | Rust     |
-|----------------------|--------------|-------------|-------|----------|----------|
-| 3.x.x                | ^5.0.0       | ^5.0.0      | 1.x.x | >=20.0.0 | >=1.85.1 |
-| 2.x.x                | ^5.0.0       | ^5.0.0      | ❌     | >=16.0.0 | >=1.30.0 |
-| 1.x.x                | ^5.0.0       | ❌           | ❌     | >=16.0.0 | >=1.30.0 |
-| 0.x.x                | ⚠️           | ❌           | ❌     | >=14.0.0 | >=1.30.0 |
+| rust-wasmpack-loader | Webpack-node | Webpack-web | Bun   | Node.js   | Rust     |
+|----------------------|--------------|-------------|-------|-----------|----------|
+| 4.x.x                | ^5.0.0       | ^5.0.0      | 1.x.x | >=22.22.2 | >=1.88.0 |
+| 3.x.x                | ^5.0.0       | ^5.0.0      | 1.x.x | >=20.0.0  | >=1.85.1 |
+| 2.x.x                | ^5.0.0       | ^5.0.0      | ❌     | >=16.0.0  | >=1.30.0 |
+| 1.x.x                | ^5.0.0       | ❌           | ❌     | >=16.0.0  | >=1.30.0 |
+| 0.x.x                | ⚠️           | ❌           | ❌     | >=14.0.0  | >=1.30.0 |
 
 
 ### Install as Dependency

--- a/docs/docs/getting-started/prerequisites.mdx
+++ b/docs/docs/getting-started/prerequisites.mdx
@@ -19,17 +19,17 @@ Before you can use rust-wasmpack-loader, you need to set up your development env
 
 ### Version Compatibility
 
-| Tool    | Minimum Version | Recommended |
-|---------|-----------------|-------------|
-| Node.js | 18.0.0          | 20.x.x      |
-| Rust    | 1.30.0          | >1.85.0     |
-| npm     | 10.0.0          | Latest      |
+| Tool    | Minimum Version | Recommended   |
+|---------|-----------------|---------------|
+| Node.js | 22.22.2         | 22.x.x (LTS)  |
+| Rust    | 1.88.0          | latest stable |
+| npm     | 10.0.0          | Latest        |
 
 ## Required Software
 
 ### 1. Node.js
 
-rust-wasmpack-loader requires Node.js version 18.0.0 or higher.
+rust-wasmpack-loader requires Node.js version 22.22.2 or higher.
 
 :::tip Best Practice
 We recommend using [Volta](https://volta.sh/) for managing Node.js versions. Volta helps ensure consistent Node.js environments across development and CI/CD systems.
@@ -43,7 +43,7 @@ We recommend using [Volta](https://volta.sh/) for managing Node.js versions. Vol
         ```bash
         # Using Volta (recommended)
         curl https://get.volta.sh | bash
-        volta install node@20
+        volta install node@22
 
         # Using winget
         winget install OpenJS.NodeJS
@@ -60,13 +60,13 @@ We recommend using [Volta](https://volta.sh/) for managing Node.js versions. Vol
         ```bash
         # Using Volta (recommended)
         curl https://get.volta.sh | bash
-        volta install node@20
+        volta install node@22
 
         # Using Homebrew
         brew install node
 
         # Using MacPorts
-        sudo port install nodejs20
+        sudo port install nodejs22
 
         # Or download from https://nodejs.org/
         ```
@@ -77,13 +77,13 @@ We recommend using [Volta](https://volta.sh/) for managing Node.js versions. Vol
         ```bash
         # Using Volta (recommended)
         curl https://get.volta.sh | bash
-        volta install node@20
+        volta install node@22
         ```
 
         **Ubuntu/Debian:**
         ```bash
         # Using NodeSource repository
-        curl -fsSL https://deb.nodesource.com/setup_20.x | sudo -E bash -
+        curl -fsSL https://deb.nodesource.com/setup_22.x | sudo -E bash -
         sudo apt-get install -y nodejs
 
         # Using snap
@@ -93,7 +93,7 @@ We recommend using [Volta](https://volta.sh/) for managing Node.js versions. Vol
         **CentOS/RHEL:**
         ```bash
         # Using NodeSource repository
-        curl -fsSL https://rpm.nodesource.com/setup_20.x | sudo bash -
+        curl -fsSL https://rpm.nodesource.com/setup_22.x | sudo bash -
         sudo yum install -y nodejs npm
         ```
 
@@ -103,7 +103,7 @@ We recommend using [Volta](https://volta.sh/) for managing Node.js versions. Vol
 #### Verify Installation
 
 ```bash
-node --version  # Should show v20.0.0 or higher
+node --version  # Should show v22.22.2 or higher
 npm --version   # Should show 10.0.0 or higher
 
 # If using Volta
@@ -112,7 +112,7 @@ volta list  # Should show the installed Node.js version
 
 ### 2. Rust
 
-Rust is required to compile your `.rs` files to WebAssembly.
+Rust is required to compile your `.rs` files to WebAssembly. Building `.rs` sources uses wasm-pack 0.15, which requires Rust 1.88.0 or higher.
 
 #### Installation
 
@@ -148,8 +148,8 @@ Rust is required to compile your `.rs` files to WebAssembly.
 #### Verify Installation
 
 ```bash
-rustc --version    # Should show 1.30.0 or higher
-cargo --version    # Should show 1.30.0 or higher
+rustc --version    # Should show 1.88.0 or higher
+cargo --version    # Should show 1.88.0 or higher
 ```
 ---
 

--- a/example/node-bun/package-lock.json
+++ b/example/node-bun/package-lock.json
@@ -20,7 +20,7 @@
                 "lodash": "^4.18.1",
                 "schema-utils": "^4.3.3",
                 "toml": "^4.1.1",
-                "wasm-pack": "^0.13.1",
+                "wasm-pack": "^0.15.0",
                 "which": "^7.0.0"
             },
             "devDependencies": {
@@ -37,7 +37,7 @@
                 "typescript": "^5.9.3"
             },
             "engines": {
-                "node": ">=20.0.0"
+                "node": ">=22.22.2"
             },
             "peerDependencies": {
                 "bun": "1.x.x",

--- a/example/node-webpack/package-lock.json
+++ b/example/node-webpack/package-lock.json
@@ -36,7 +36,7 @@
                 "lodash": "^4.18.1",
                 "schema-utils": "^4.3.3",
                 "toml": "^4.1.1",
-                "wasm-pack": "^0.13.1",
+                "wasm-pack": "^0.15.0",
                 "which": "^7.0.0"
             },
             "devDependencies": {
@@ -53,7 +53,7 @@
                 "typescript": "^5.9.3"
             },
             "engines": {
-                "node": ">=20.0.0"
+                "node": ">=22.22.2"
             },
             "peerDependencies": {
                 "bun": "1.x.x",
@@ -13488,7 +13488,7 @@
                 "schema-utils": "^4.3.3",
                 "toml": "^4.1.1",
                 "typescript": "^5.9.3",
-                "wasm-pack": "^0.13.1",
+                "wasm-pack": "^0.15.0",
                 "which": "^7.0.0"
             }
         },

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
                 "lodash": "^4.18.1",
                 "schema-utils": "^4.3.3",
                 "toml": "^4.1.1",
-                "wasm-pack": "^0.13.1",
+                "wasm-pack": "^0.15.0",
                 "which": "^7.0.0"
             },
             "devDependencies": {
@@ -31,7 +31,7 @@
                 "typescript": "^5.9.3"
             },
             "engines": {
-                "node": ">=20.0.0"
+                "node": ">=22.22.2"
             },
             "peerDependencies": {
                 "bun": "1.x.x",
@@ -574,6 +574,18 @@
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/nzakas"
+            }
+        },
+        "node_modules/@isaacs/fs-minipass": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz",
+            "integrity": "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==",
+            "license": "ISC",
+            "dependencies": {
+                "minipass": "^7.0.4"
+            },
+            "engines": {
+                "node": ">=18.0.0"
             }
         },
         "node_modules/@jridgewell/gen-mapping": {
@@ -1681,15 +1693,6 @@
                 "node": ">=4"
             }
         },
-        "node_modules/axios": {
-            "version": "0.26.1",
-            "resolved": "https://registry.npmjs.org/axios/-/axios-0.26.1.tgz",
-            "integrity": "sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==",
-            "license": "MIT",
-            "dependencies": {
-                "follow-redirects": "^1.14.8"
-            }
-        },
         "node_modules/axobject-query": {
             "version": "4.1.0",
             "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-4.1.0.tgz",
@@ -1704,6 +1707,7 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
             "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/baseline-browser-mapping": {
@@ -1719,25 +1723,11 @@
                 "node": ">=6.0.0"
             }
         },
-        "node_modules/binary-install": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/binary-install/-/binary-install-1.1.2.tgz",
-            "integrity": "sha512-ZS2cqFHPZOy4wLxvzqfQvDjCOifn+7uCPqNmYRIBM/03+yllON+4fNnsD0VJdW0p97y+E+dTRNPStWNqMBq+9g==",
-            "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
-            "license": "MIT",
-            "dependencies": {
-                "axios": "^0.26.1",
-                "rimraf": "^3.0.2",
-                "tar": "^6.1.11"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
         "node_modules/brace-expansion": {
             "version": "1.1.12",
             "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
             "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "balanced-match": "^1.0.0",
@@ -1900,12 +1890,12 @@
             }
         },
         "node_modules/chownr": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
-            "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
-            "license": "ISC",
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
+            "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
+            "license": "BlueOak-1.0.0",
             "engines": {
-                "node": ">=10"
+                "node": ">=18"
             }
         },
         "node_modules/clsx": {
@@ -1952,6 +1942,7 @@
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
             "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/confusing-browser-globals": {
@@ -3238,26 +3229,6 @@
             "dev": true,
             "license": "ISC"
         },
-        "node_modules/follow-redirects": {
-            "version": "1.16.0",
-            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
-            "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
-            "funding": [
-                {
-                    "type": "individual",
-                    "url": "https://github.com/sponsors/RubenVerborgh"
-                }
-            ],
-            "license": "MIT",
-            "engines": {
-                "node": ">=4.0"
-            },
-            "peerDependenciesMeta": {
-                "debug": {
-                    "optional": true
-                }
-            }
-        },
         "node_modules/for-each": {
             "version": "0.3.5",
             "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
@@ -3273,36 +3244,6 @@
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
-        },
-        "node_modules/fs-minipass": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
-            "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
-            "license": "ISC",
-            "dependencies": {
-                "minipass": "^3.0.0"
-            },
-            "engines": {
-                "node": ">= 8"
-            }
-        },
-        "node_modules/fs-minipass/node_modules/minipass": {
-            "version": "3.3.6",
-            "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
-            "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
-            "license": "ISC",
-            "dependencies": {
-                "yallist": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/fs.realpath": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-            "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
-            "license": "ISC"
         },
         "node_modules/function-bind": {
             "version": "1.1.2",
@@ -3433,27 +3374,6 @@
             },
             "funding": {
                 "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
-            }
-        },
-        "node_modules/glob": {
-            "version": "7.2.3",
-            "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-            "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-            "deprecated": "Glob versions prior to v9 are no longer supported",
-            "license": "ISC",
-            "dependencies": {
-                "fs.realpath": "^1.0.0",
-                "inflight": "^1.0.4",
-                "inherits": "2",
-                "minimatch": "^3.1.1",
-                "once": "^1.3.0",
-                "path-is-absolute": "^1.0.0"
-            },
-            "engines": {
-                "node": "*"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
             }
         },
         "node_modules/glob-parent": {
@@ -3673,23 +3593,6 @@
             "engines": {
                 "node": ">=0.8.19"
             }
-        },
-        "node_modules/inflight": {
-            "version": "1.0.6",
-            "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-            "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
-            "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
-            "license": "ISC",
-            "dependencies": {
-                "once": "^1.3.0",
-                "wrappy": "1"
-            }
-        },
-        "node_modules/inherits": {
-            "version": "2.0.4",
-            "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-            "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-            "license": "ISC"
         },
         "node_modules/internal-slot": {
             "version": "1.1.0",
@@ -4421,6 +4324,7 @@
             "version": "3.1.5",
             "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
             "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "brace-expansion": "^1.1.7"
@@ -4440,49 +4344,24 @@
             }
         },
         "node_modules/minipass": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
-            "integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
-            "license": "ISC",
+            "version": "7.1.3",
+            "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+            "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+            "license": "BlueOak-1.0.0",
             "engines": {
-                "node": ">=8"
+                "node": ">=16 || 14 >=14.17"
             }
         },
         "node_modules/minizlib": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
-            "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
+            "integrity": "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==",
             "license": "MIT",
             "dependencies": {
-                "minipass": "^3.0.0",
-                "yallist": "^4.0.0"
+                "minipass": "^7.1.2"
             },
             "engines": {
-                "node": ">= 8"
-            }
-        },
-        "node_modules/minizlib/node_modules/minipass": {
-            "version": "3.3.6",
-            "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
-            "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
-            "license": "ISC",
-            "dependencies": {
-                "yallist": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/mkdirp": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-            "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
-            "license": "MIT",
-            "bin": {
-                "mkdirp": "bin/cmd.js"
-            },
-            "engines": {
-                "node": ">=10"
+                "node": ">= 18"
             }
         },
         "node_modules/ms": {
@@ -4692,15 +4571,6 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/once": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-            "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-            "license": "ISC",
-            "dependencies": {
-                "wrappy": "1"
-            }
-        },
         "node_modules/optionator": {
             "version": "0.9.4",
             "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -4790,15 +4660,6 @@
             "license": "MIT",
             "engines": {
                 "node": ">=8"
-            }
-        },
-        "node_modules/path-is-absolute": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-            "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.10.0"
             }
         },
         "node_modules/path-key": {
@@ -5065,22 +4926,6 @@
             "engines": {
                 "iojs": ">=1.0.0",
                 "node": ">=0.10.0"
-            }
-        },
-        "node_modules/rimraf": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-            "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-            "deprecated": "Rimraf versions prior to v4 are no longer supported",
-            "license": "ISC",
-            "dependencies": {
-                "glob": "^7.1.3"
-            },
-            "bin": {
-                "rimraf": "bin.js"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
             }
         },
         "node_modules/run-parallel": {
@@ -5602,21 +5447,19 @@
             }
         },
         "node_modules/tar": {
-            "version": "6.2.1",
-            "resolved": "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz",
-            "integrity": "sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==",
-            "deprecated": "Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
-            "license": "ISC",
+            "version": "7.5.16",
+            "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.16.tgz",
+            "integrity": "sha512-56adEpPMouktRlBLXiaYFFzZ/3+JXa8P9n7WbR+ibIjtviN55mEaOkiysCnPnWm+7kkui1Dn8J9l+g6zV8731w==",
+            "license": "BlueOak-1.0.0",
             "dependencies": {
-                "chownr": "^2.0.0",
-                "fs-minipass": "^2.0.0",
-                "minipass": "^5.0.0",
-                "minizlib": "^2.1.1",
-                "mkdirp": "^1.0.3",
-                "yallist": "^4.0.0"
+                "@isaacs/fs-minipass": "^4.0.0",
+                "chownr": "^3.0.0",
+                "minipass": "^7.1.2",
+                "minizlib": "^3.1.0",
+                "yallist": "^5.0.0"
             },
             "engines": {
-                "node": ">=10"
+                "node": ">=18"
             }
         },
         "node_modules/tinyglobby": {
@@ -5950,16 +5793,19 @@
             }
         },
         "node_modules/wasm-pack": {
-            "version": "0.13.1",
-            "resolved": "https://registry.npmjs.org/wasm-pack/-/wasm-pack-0.13.1.tgz",
-            "integrity": "sha512-P9exD4YkjpDbw68xUhF3MDm/CC/3eTmmthyG5bHJ56kalxOTewOunxTke4SyF8MTXV6jUtNjXggPgrGmMtczGg==",
+            "version": "0.15.0",
+            "resolved": "https://registry.npmjs.org/wasm-pack/-/wasm-pack-0.15.0.tgz",
+            "integrity": "sha512-DdqtGWc3+iFx+7lL7QU5LBWs7qMnwQSWxF0htSfE15sNa3roVwHjAkTm2JXgueU2GGfSwNqbq2EzyC2b/biKDA==",
             "hasInstallScript": true,
             "license": "MIT OR Apache-2.0",
             "dependencies": {
-                "binary-install": "^1.0.1"
+                "tar": "^7.5.3"
             },
             "bin": {
                 "wasm-pack": "run.js"
+            },
+            "engines": {
+                "node": ">=16"
             }
         },
         "node_modules/which": {
@@ -6076,17 +5922,14 @@
                 "node": ">=0.10.0"
             }
         },
-        "node_modules/wrappy": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-            "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-            "license": "ISC"
-        },
         "node_modules/yallist": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-            "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-            "license": "ISC"
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
+            "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
+            "license": "BlueOak-1.0.0",
+            "engines": {
+                "node": ">=18"
+            }
         },
         "node_modules/yocto-queue": {
             "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
         "lodash": "^4.18.1",
         "schema-utils": "^4.3.3",
         "toml": "^4.1.1",
-        "wasm-pack": "^0.13.1",
+        "wasm-pack": "^0.15.0",
         "which": "^7.0.0"
     },
     "peerDependencies": {


### PR DESCRIPTION
## Summary

Re-applies the wasm-pack 0.13.1 -> 0.15.0 bump that was held back from the safe-deps release. wasm-pack 0.15 installs wasm-bindgen 0.2.95, whose toolchain requires rustc 1.88, so the CI rust matrix drops the now-unsupported older versions and tests rust [1.88.0, 1.93.0].

## Notes for reviewers

- Breaking: building .rs sources now requires Rust >= 1.88.
- wasm-pack 0.15 also drops a chunk of transitive deps (the old binary-install/axios chain), shrinking the lockfile.
- Verifiable only by CI - the dev host can't build the Rust examples (missing Windows SDK). Watching the matrix on this PR.
