### PR TITLE
[RL-50] upgrade TypeScript to 6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
                 "npm-check-updates": "^22.2.7",
                 "prettier": "^3.8.4",
                 "prism-react-renderer": "^2.4.1",
-                "typescript": "^5.9.3"
+                "typescript": "^6.0.3"
             },
             "engines": {
                 "node": ">=22.22.2"
@@ -5650,9 +5650,9 @@
             }
         },
         "node_modules/typescript": {
-            "version": "5.9.3",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-            "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+            "version": "6.0.3",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+            "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
             "dev": true,
             "license": "Apache-2.0",
             "bin": {

--- a/package.json
+++ b/package.json
@@ -122,7 +122,7 @@
         "npm-check-updates": "^22.2.7",
         "prettier": "^3.8.4",
         "prism-react-renderer": "^2.4.1",
-        "typescript": "^5.9.3"
+        "typescript": "^6.0.3"
     },
     "engines": {
         "node": ">=22.22.2"


### PR DESCRIPTION
## Summary

Bumps the TypeScript devDependency 5.9.3 -> 6.0.3. TypeScript is internal tooling only (type-aware linting + @types/bun); it is not shipped (the `files` allowlist excludes it) and has no consumer-facing impact. `npx eslint .` passes clean with no typescript-eslint unsupported-version warning.

## Notes for reviewers

- Dev-only; not a runtime or API change, and no docs reference TypeScript as a consumer requirement.
- CI does not lint, so this is verified locally (eslint, no Rust). The example matrix on this PR confirms no incidental breakage.
