### PR TITLE
[RL-53] add a first-class esbuild plugin

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
                 os: [ ubuntu-latest, ubuntu-24.04-arm, windows-latest, macos-latest ]
                 node: [ 22, 24 ]
                 rust: [ "1.88.0", "1.93.0" ]
-                test: [ example/node-bun, example/node-webpack ]
+                test: [ example/node-bun, example/node-webpack, example/esbuild ]
         steps:
             -   uses: actions/checkout@v5
             -   uses: actions/setup-node@v5

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ rust-wasmpack-loader is a native WASM loader for `.rs` (Rust) resources that wor
 
 - [**Webpack**](https://webpack.js.org/) `^5.0.0` (Both `web` and `node` (`node-async`) targets)
 - [**Bun**](https://bun.sh/) runtime (node target only)
+- [**esbuild**](https://esbuild.github.io/) plugin (`node` and `web` targets, inline WASM)
 
 ## Key Features
 
@@ -27,6 +28,8 @@ rust-wasmpack-loader is a native WASM loader for `.rs` (Rust) resources that wor
 🌐 **Multi-Target Webpack Support** — Works with `web` and `node` applications
 
 ⚡ **Bun Compatible** — Full support for Bun runtime (node target only for now)
+
+📦 **esbuild Plugin** — First-class esbuild plugin for `node` and `web` builds
 
 ## Why Use rust-wasmpack-loader?
 
@@ -78,6 +81,8 @@ better understanding of how the loader works with different setups:
 - **[Node.js Webpack](https://github.com/yeskiy/rustwasm-loader/tree/main/example/node-webpack)** - Server-side
   applications
 - **[Bun Node.js](https://github.com/yeskiy/rustwasm-loader/tree/main/example/node-bun)** - High-performance Bun runtime
+- **[esbuild](https://github.com/yeskiy/rustwasm-loader/tree/main/example/esbuild)** - Fast bundling for Node.js or the
+  browser
 
 ## Contributing
 

--- a/docs/docs/examples/esbuild.md
+++ b/docs/docs/examples/esbuild.md
@@ -1,0 +1,146 @@
+---
+sidebar_position: 4
+---
+
+# esbuild Example
+
+This example demonstrates how to use rust-wasmpack-loader with [esbuild](https://esbuild.github.io/). esbuild is an
+extremely fast bundler, and the loader ships a first-class plugin so you can import `.rs` files directly from your build.
+
+The plugin inlines the compiled WebAssembly as bytes into the generated JavaScript, so no extra asset handling is needed.
+It picks the build strategy from esbuild's `platform` option: `node` builds for Node.js, while `browser`, `neutral`, and
+the default target a browser-like environment.
+
+## Project Structure
+
+```
+esbuild-example/
+├── src/
+│   ├── index.js          # Entry point importing the .rs module
+│   └── lib.rs            # Rust WebAssembly code
+├── dist/                 # Build output
+├── build.mjs            # esbuild build script wiring up the plugin
+├── Cargo.toml           # Rust configuration
+└── package.json         # Dependencies and scripts
+```
+
+## Setup Instructions
+
+### 1. Initialize Project
+
+```bash
+mkdir my-esbuild-wasm-app
+cd my-esbuild-wasm-app
+npm init -y
+```
+
+### 2. Install Dependencies
+
+```bash
+npm install --save-dev rust-wasmpack-loader esbuild
+```
+
+### 3. Create Cargo.toml
+
+```toml title="Cargo.toml"
+[package]
+name = "esbuild-wasm-example"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+wasm-bindgen = "0.2.95"
+```
+
+### 4. Create Rust Code
+
+```rust title="src/lib.rs"
+use wasm_bindgen::prelude::*;
+
+#[wasm_bindgen]
+pub fn fibonacci(n: u32) -> u32 {
+    match n {
+        0 => 0,
+        1 => 1,
+        _ => fibonacci(n - 1) + fibonacci(n - 2),
+    }
+}
+
+#[wasm_bindgen]
+pub fn greet(name: &str) -> String {
+    format!("Hello, {}! Greetings from Rust via esbuild!", name)
+}
+```
+
+### 5. Create the Entry Point
+
+```javascript title="src/index.js"
+import wasmModule from "./lib.rs";
+
+console.log(wasmModule.greet("esbuild Developer"));
+console.log(`fibonacci(10) = ${wasmModule.fibonacci(10)}`);
+```
+
+### 6. Create the Build Script
+
+```javascript title="build.mjs"
+import * as esbuild from "esbuild";
+import rustWasmLoader from "rust-wasmpack-loader";
+
+await esbuild.build({
+    entryPoints: ["src/index.js"],
+    bundle: true,
+    format: "esm",
+    platform: "node",
+    outdir: "dist",
+    logLevel: "info",
+    plugins: [rustWasmLoader.esbuild({ logLevel: "info" })],
+});
+```
+
+For browser output, set `platform: "browser"` (or leave it unset) - the plugin will build the web strategy and inline the
+WebAssembly into the bundle.
+
+### 7. Update Package.json
+
+```json title="package.json"
+{
+    ...,
+    "type": "module",
+    "scripts": {
+        "build": "node build.mjs",
+        "start": "node build.mjs && node dist/index.js"
+    },
+    ...
+}
+```
+
+## Running the Example
+
+```bash
+# Build the bundle
+npm run build
+
+# Build and run it
+npm start
+```
+
+## Plugin Options
+
+The esbuild plugin accepts the same `logLevel` option as the other targets:
+
+```javascript
+rustWasmLoader.esbuild({
+    logLevel: "info", // "verbose" | "info" | "warn" | "error" | "quiet"
+});
+```
+
+---
+
+:::tip Inline delivery
+The esbuild plugin currently inlines the `.wasm` bytes into the generated JavaScript. This keeps configuration to zero -
+there is no separate asset to copy or serve. Separate-asset delivery may arrive as a later enhancement.
+:::

--- a/docs/docs/examples/index.md
+++ b/docs/docs/examples/index.md
@@ -13,4 +13,5 @@ example includes complete setup instructions, configuration files, and working c
 
 - **[Node.js Webpack](./examples/node-webpack)** - Server-side applications using Webpack
 - **[⚡Bun](./examples/node-bun)** - High-performance applications using Bun runtime
+- **[esbuild](./examples/esbuild)** - Fast bundling for Node.js or the browser using esbuild
 

--- a/docs/docs/getting-started/overview.mdx
+++ b/docs/docs/getting-started/overview.mdx
@@ -32,6 +32,7 @@ graph LR
 - **TypeScript integration** with generated type definitions
 - **Webpack 5+** support with explicit targets (web, node)
 - **Bun runtime** compatibility for modern JavaScript environments
+- **esbuild plugin** for fast bundling on Node.js or the browser
 
 ## Use Cases
 
@@ -52,12 +53,12 @@ graph LR
 
 ## Supported Targets
 
-| Target       | Webpack           | Bun |
-|--------------|-------------------|-----|
-| `web`        | ✅                 | ❌   |
-| `node`       | ✅                 | ✅   |
-| `node-async` | ✅                 | ✅   |
-| `electron`   | ⚠️ *(not tested)* | ❌   |
+| Target       | Webpack           | Bun | esbuild |
+|--------------|-------------------|-----|---------|
+| `web`        | ✅                 | ❌   | ✅       |
+| `node`       | ✅                 | ✅   | ✅       |
+| `node-async` | ✅                 | ✅   | ❌       |
+| `electron`   | ⚠️ *(not tested)* | ❌   | ❌       |
 
 ## Comparison with Alternatives
 
@@ -78,7 +79,7 @@ graph LR
 | **Bun runtime support**       | ✅                    | 🤚               | ❌                           | ❌                | ❌           | 🤚           | 🤚               |
 | **Webpack integration**       | ✅                    | ❌                | ✅                           | ❌                | ❌           | ❌            | ⚠️               |
 | **Vite/Rollup integration**   | ❌                    | ❌                | ❌                           | ✅                | ✅           | ❌            | ⚠️               |
-| **esbuild integration**       | ❌                    | ❌                | ❌                           | ❌                | ❌           | ✅            | ⚠️               |
+| **esbuild integration**       | ✅                    | ❌                | ❌                           | ❌                | ❌           | ✅            | ⚠️               |
 | **TypeScript bindings**       | ✅                    | ✅                | ✅                           | ✅                | ✅           | ✅            | ❌                |
 | **Zero configuration**        | ✅                    | ❌                | ❌                           | ❌                | ❌           | ❌            | ❌                |
 | **Async WASM loading**        | ✅                    | ✅                | ✅                           | ✅                | ✅           | ✅            | ✅                |
@@ -95,7 +96,7 @@ graph LR
 - Offering **native Bun runtime support** (unique in the ecosystem)
 - Providing **automatic Cargo.toml discovery** up the directory tree
 - Requiring **zero configuration** for basic usage
-- Supporting both **Webpack and Bun** in a single package
+- Supporting **Webpack, Bun, and esbuild** from a single package
 
 **Alternative approaches:**
 - **Manual wasm-pack**: Requires separate build steps and manual integration

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -20,6 +20,7 @@ const sidebars = {
                 "docs/examples/web-webpack",
                 "docs/examples/node-webpack",
                 "docs/examples/node-bun",
+                "docs/examples/esbuild",
             ],
         },
         {

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -112,4 +112,14 @@ export default defineConfig([
             "import-x/no-extraneous-dependencies": "off",
         },
     },
+
+    // --- Example build scripts (resolve deps only after the example is installed) ---
+    {
+        name: "project/example-build-scripts",
+        files: ["example/**/build.mjs"],
+        rules: {
+            "import-x/no-unresolved": "off",
+            "import-x/no-extraneous-dependencies": "off",
+        },
+    },
 ]);

--- a/example/esbuild/.gitignore
+++ b/example/esbuild/.gitignore
@@ -1,0 +1,3 @@
+/dist
+/node_modules
+/target

--- a/example/esbuild/Cargo.toml
+++ b/example/esbuild/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "wasm-fibonacci-test"
+version = "0.1.0"
+authors = ["Yehor Brodskiy"]
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+wasm-bindgen = "0.2.95"

--- a/example/esbuild/build.mjs
+++ b/example/esbuild/build.mjs
@@ -1,0 +1,12 @@
+import * as esbuild from "esbuild";
+import rustWasmLoader from "rust-wasmpack-loader";
+
+await esbuild.build({
+    entryPoints: ["src/index.js", "src/index.test.js"],
+    bundle: true,
+    format: "esm",
+    platform: "node",
+    outdir: "dist",
+    logLevel: "info",
+    plugins: [rustWasmLoader.esbuild({ logLevel: "info" })],
+});

--- a/example/esbuild/package.json
+++ b/example/esbuild/package.json
@@ -1,0 +1,15 @@
+{
+    "type": "module",
+    "engines": {
+        "node": ">=22.22.2"
+    },
+    "scripts": {
+        "build": "node build.mjs",
+        "start": "node build.mjs && node dist/index.js",
+        "test": "node build.mjs && node --test dist/index.test.js"
+    },
+    "devDependencies": {
+        "esbuild": "^0.25.0",
+        "rust-wasmpack-loader": "file:../.."
+    }
+}

--- a/example/esbuild/src/index.js
+++ b/example/esbuild/src/index.js
@@ -1,0 +1,7 @@
+import rsLib from "./lib.rs";
+
+const NUM = 10;
+
+console.log(`fibonacci_bindgen(${NUM}) = ${rsLib.fibonacci_bindgen(NUM)}`);
+console.log(`fibonacci_default(${NUM}) = ${rsLib.fibonacci_default(NUM)}`);
+console.log(`cap("hello") = ${rsLib.cap("hello")}`);

--- a/example/esbuild/src/index.test.js
+++ b/example/esbuild/src/index.test.js
@@ -1,0 +1,17 @@
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import rsLib from "./lib.rs";
+
+describe("esbuild", () => {
+    test("fibonacci_bindgen", () => {
+        assert.equal(rsLib.fibonacci_bindgen(10), 55);
+    });
+
+    test("fibonacci_default", () => {
+        assert.equal(rsLib.fibonacci_default(10), 55);
+    });
+
+    test("cap", () => {
+        assert.equal(rsLib.cap("hello"), "Hello");
+    });
+});

--- a/example/esbuild/src/lib.rs
+++ b/example/esbuild/src/lib.rs
@@ -1,0 +1,26 @@
+extern crate wasm_bindgen;
+
+use wasm_bindgen::prelude::*;
+
+#[no_mangle]
+pub fn fibonacci_default(n: i32) -> i32 {
+    match n {
+        0 => 0,
+        1 => 1,
+        _ => fibonacci_default(n - 1) + fibonacci_default(n - 2),
+    }
+}
+
+#[wasm_bindgen]
+pub fn fibonacci_bindgen(n: i32) -> i32 {
+    match n {
+        0 => 0,
+        1 => 1,
+        _ => fibonacci_bindgen(n - 1) + fibonacci_bindgen(n - 2),
+    }
+}
+
+#[wasm_bindgen]
+pub fn cap(s: &str) -> String {
+    s[0..1].to_uppercase() + &s[1..]
+}

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "main": "./src/index.js",
     "scripts": {
         "release": "npx commit-and-tag-version && npm run postrelease",
-        "postrelease": "cd ./example/node-webpack && npm i && cd ../../ && cd ./example/web-webpack && npm i && cd ../../ && cd ./example/node-bun && npm i",
+        "postrelease": "cd ./example/node-webpack && npm i && cd ../../ && cd ./example/web-webpack && npm i && cd ../../ && cd ./example/node-bun && npm i && cd ../../ && cd ./example/esbuild && npm i",
         "docs:start": "docusaurus start --config ./docs/docusaurus.config.js",
         "docs:build": "docusaurus build --config ./docs/docusaurus.config.js",
         "docs:swizzle": "docusaurus swizzle --config ./docs/docusaurus.config.js",
@@ -101,10 +101,14 @@
     },
     "peerDependencies": {
         "bun": "1.x.x",
+        "esbuild": ">=0.17.0",
         "webpack": "^5.0.0"
     },
     "peerDependenciesMeta": {
         "bun": {
+            "optional": true
+        },
+        "esbuild": {
             "optional": true
         },
         "webpack": {

--- a/src/esbuild.js
+++ b/src/esbuild.js
@@ -14,7 +14,11 @@ const optionsSchema = {
     additionalProperties: false,
 };
 
-module.exports = function bun(config) {
+// esbuild's `platform: "node"` builds for Node.js; "browser", "neutral", and
+// the default (undefined) all target a browser-like environment.
+const targetForPlatform = (platform) => (platform === "node" ? "node" : "web");
+
+module.exports = function esbuild(config) {
     const options = merge(
         {
             logLevel: "info",
@@ -27,14 +31,14 @@ module.exports = function bun(config) {
     });
 
     return {
-        target: "node",
         name: "rust-wasmpack-loader",
-        async setup(build) {
+        setup(build) {
             build.onLoad({ filter: /\.rs$/ }, async (args) =>
                 sharedLoad({
                     resourcePath: args.path,
-                    baseFolder: process.cwd(),
-                    target: "node",
+                    baseFolder:
+                        build.initialOptions.absWorkingDir || process.cwd(),
+                    target: targetForPlatform(build.initialOptions.platform),
                     logLevel: options.logLevel,
                 }),
             );

--- a/src/index.js
+++ b/src/index.js
@@ -7,6 +7,7 @@ const schemaUtils = require("schema-utils");
 const { merge } = require("lodash");
 const pack = require("./pack");
 const bun = require("./bun");
+const esbuild = require("./esbuild");
 
 const optionsSchema = {
     type: "object",
@@ -164,4 +165,5 @@ async function rustWasmLoader(source) {
 }
 
 rustWasmLoader.bun = bun;
+rustWasmLoader.esbuild = esbuild;
 module.exports = rustWasmLoader;

--- a/src/shared-load.util.js
+++ b/src/shared-load.util.js
@@ -1,0 +1,62 @@
+const fs = require("node:fs");
+const path = require("node:path");
+const os = require("node:os");
+const crypto = require("node:crypto");
+const pack = require("./pack");
+
+/** @typedef {Object} SharedLoadParams
+ * @property {string} resourcePath - absolute path to the .rs file being loaded
+ * @property {string} target - pack target ("node" or "web")
+ * @property {string} logLevel - log level passed to wasm-pack
+ * @property {string} [baseFolder] - project root used to resolve Cargo.toml (defaults to cwd)
+ */
+
+/**
+ * Shared onLoad routine for esbuild-compatible plugins (Bun and esbuild).
+ * Reads the .rs source, builds it through wasm-pack into a per-source temp dir,
+ * and returns the generated JS with the wasm inlined as bytes.
+ * @param {SharedLoadParams} params
+ * @returns {Promise<{ contents: string, loader: "js" }>}
+ */
+module.exports = async function sharedLoad(params) {
+    const baseFolder = params.baseFolder || process.cwd();
+    const source = fs.readFileSync(params.resourcePath, "utf8");
+    const { base } = path.parse(path.normalize(params.resourcePath));
+
+    // Create a build folder and name with md5 of a source
+    const hash = crypto.createHash("md5").update(source).digest("hex");
+    const buildFolder = path.join(os.tmpdir(), `${base}.${hash}`);
+
+    // create required folders for build
+    if (!fs.existsSync(buildFolder)) {
+        fs.mkdirSync(buildFolder, { recursive: true });
+    }
+
+    const contents = await pack(
+        {
+            resourcePath: params.resourcePath,
+            baseFolder,
+            target: params.target,
+            buildFolder,
+            wasmName: `${hash}.wasm`,
+            logLevel: params.logLevel,
+            web: {
+                asyncLoading: false,
+                usePublicPath: false,
+                publicPath: [],
+                wasmPathModifier: ["/"],
+            },
+            node: {
+                bundle: true,
+            },
+        },
+        async () => {
+            //  ignore
+        },
+    );
+
+    return {
+        contents,
+        loader: "js",
+    };
+};


### PR DESCRIPTION
## Summary

Adds esbuild as a first-class target. The shared onLoad logic is factored out of the Bun plugin into `src/shared-load.util.js` (behavior-preserving for Bun), and `src/esbuild.js` exposes an esbuild plugin via `rustWasmLoader.esbuild`. It compiles `.rs` imports through wasm-pack and selects the node vs web strategy from esbuild's `platform`, inlining the wasm bytes so no esbuild asset configuration is needed. A new `example/esbuild` project is added to the CI matrix, with docs and README updated.

## Notes for reviewers

- The Bun plugin refactor is behavior-preserving (it now calls the shared helper); the webpack loader is untouched.
- v1 uses inline wasm delivery; a separate-asset/import mode is a later enhancement (the engine refactor).
- The esbuild example's actual Rust build is verified by CI (the dev host lacks the Windows SDK). Local checks: eslint clean, plugin require/shape sanity.
- esbuild added to peerDependenciesMeta as optional, matching bun/webpack.
