### PR TITLE
[RL-54] support Rspack via the existing webpack loader

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
                 os: [ ubuntu-latest, ubuntu-24.04-arm, windows-latest, macos-latest ]
                 node: [ 22, 24 ]
                 rust: [ "1.88.0", "1.93.0" ]
-                test: [ example/node-bun, example/node-webpack, example/esbuild ]
+                test: [ example/node-bun, example/node-webpack, example/esbuild, example/rspack ]
         steps:
             -   uses: actions/checkout@v5
             -   uses: actions/setup-node@v5

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ your JavaScript/TypeScript projects through WebAssembly (WASM).
 rust-wasmpack-loader is a native WASM loader for `.rs` (Rust) resources that works with:
 
 - [**Webpack**](https://webpack.js.org/) `^5.0.0` (Both `web` and `node` (`node-async`) targets)
+- [**Rspack**](https://rspack.rs/) `>=1.0.0` (same Webpack-compatible loader, `web` and `node` targets)
 - [**Bun**](https://bun.sh/) runtime (node target only)
 - [**esbuild**](https://esbuild.github.io/) plugin (`node` and `web` targets, inline WASM)
 
@@ -80,6 +81,8 @@ better understanding of how the loader works with different setups:
 - **[Web Webpack](https://github.com/yeskiy/rustwasm-loader/tree/main/example/web-webpack)** - Browser applications
 - **[Node.js Webpack](https://github.com/yeskiy/rustwasm-loader/tree/main/example/node-webpack)** - Server-side
   applications
+- **[Rspack](https://github.com/yeskiy/rustwasm-loader/tree/main/example/rspack)** - Fast Rust-based bundling with the
+  Webpack-compatible loader
 - **[Bun Node.js](https://github.com/yeskiy/rustwasm-loader/tree/main/example/node-bun)** - High-performance Bun runtime
 - **[esbuild](https://github.com/yeskiy/rustwasm-loader/tree/main/example/esbuild)** - Fast bundling for Node.js or the
   browser

--- a/docs/docs/examples/index.md
+++ b/docs/docs/examples/index.md
@@ -14,4 +14,5 @@ example includes complete setup instructions, configuration files, and working c
 - **[Node.js Webpack](./examples/node-webpack)** - Server-side applications using Webpack
 - **[⚡Bun](./examples/node-bun)** - High-performance applications using Bun runtime
 - **[esbuild](./examples/esbuild)** - Fast bundling for Node.js or the browser using esbuild
+- **[Rspack](./examples/rspack)** - Fast Rust-based bundling with the Webpack-compatible loader
 

--- a/docs/docs/examples/rspack.md
+++ b/docs/docs/examples/rspack.md
@@ -1,0 +1,216 @@
+---
+sidebar_position: 5
+---
+
+# Rspack Example
+
+This example demonstrates how to use rust-wasmpack-loader with [Rspack](https://rspack.rs/). Rspack is a fast Rust-based
+bundler that mirrors the Webpack API, so the same loader you use with Webpack works here without any changes.
+
+Because Rspack reuses the Webpack loader context, you configure the `.rs` rule exactly as you would for Webpack. This
+example targets Node.js and inlines the compiled WebAssembly into the bundle via the `node.bundle` option.
+
+## Project Structure
+
+```
+rspack-example/
+├── src/
+│   ├── index.js              # Entry point importing the .rs module
+│   ├── index.test.js         # Test entry using node:test
+│   └── lib.rs                # Rust WebAssembly code
+├── dist/                     # Build output
+├── Cargo.toml                # Rust configuration
+├── package.json              # Dependencies and scripts
+├── rspack.config.js          # Rspack configuration
+└── test.rspack.config.js     # Test configuration
+```
+
+## Setup Instructions
+
+### 1. Initialize Project
+
+```bash
+mkdir my-rspack-wasm-app
+cd my-rspack-wasm-app
+npm init -y
+```
+
+### 2. Install Dependencies
+
+```bash
+npm install --save-dev rust-wasmpack-loader @rspack/core @rspack/cli webpack-node-externals
+```
+
+### 3. Create Cargo.toml
+
+```toml title="Cargo.toml"
+[package]
+name = "rspack-wasm-example"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+wasm-bindgen = "0.2.95"
+```
+
+### 4. Create Rust Code
+
+```rust title="src/lib.rs"
+use wasm_bindgen::prelude::*;
+
+#[no_mangle]
+pub fn fibonacci_default(n: i32) -> i32 {
+    match n {
+        0 => 0,
+        1 => 1,
+        _ => fibonacci_default(n - 1) + fibonacci_default(n - 2),
+    }
+}
+
+#[wasm_bindgen]
+pub fn fibonacci_bindgen(n: i32) -> i32 {
+    match n {
+        0 => 0,
+        1 => 1,
+        _ => fibonacci_bindgen(n - 1) + fibonacci_bindgen(n - 2),
+    }
+}
+
+#[wasm_bindgen]
+pub fn cap(s: &str) -> String {
+    s[0..1].to_uppercase() + &s[1..]
+}
+```
+
+### 5. Create the Entry Point
+
+```javascript title="src/index.js"
+import rsLib from "./lib.rs";
+
+const NUM = 10;
+
+console.log(`fibonacci_bindgen(${NUM}) = ${rsLib.fibonacci_bindgen(NUM)}`);
+console.log(`fibonacci_default(${NUM}) = ${rsLib.fibonacci_default(NUM)}`);
+console.log(`cap("hello") = ${rsLib.cap("hello")}`);
+```
+
+### 6. Configure Rspack
+
+```javascript title="rspack.config.js"
+const path = require("path");
+const nodeExternals = require("webpack-node-externals");
+
+module.exports = {
+    mode: "development",
+    entry: "./src/index.js",
+    output: {
+        path: path.resolve(__dirname, "dist"),
+        filename: "bundle.js",
+        clean: true,
+    },
+    target: "node",
+    node: false,
+    externals: nodeExternals(),
+    module: {
+        rules: [
+            {
+                test: /\.rs$/,
+                exclude: /node_modules/,
+                use: [
+                    {
+                        loader: "rust-wasmpack-loader",
+                        options: {
+                            node: {
+                                bundle: true,
+                            },
+                            logLevel: "info",
+                        },
+                    },
+                ],
+            },
+        ],
+    },
+    resolve: {
+        extensions: [".js", ".ts"],
+    },
+    experiments: {
+        syncWebAssembly: true,
+        asyncWebAssembly: false,
+    },
+};
+```
+
+With `node.bundle` set to `true`, the WebAssembly bytes are inlined into the generated JavaScript, so Rspack's built-in
+`webassembly/async` rule never has to handle a separate `.wasm` asset. That is why `asyncWebAssembly` is disabled and
+`syncWebAssembly` is enabled here.
+
+### 7. Update Package.json
+
+```json title="package.json"
+{
+    ...,
+    "scripts": {
+        "build": "rspack build --config rspack.config.js",
+        "start": "rspack build --config rspack.config.js --watch",
+        "test": "rspack build --config test.rspack.config.js && node --test dist/comp.test.js"
+    },
+    ...
+}
+```
+
+## Running the Example
+
+```bash
+# Build the bundle
+npm run build
+
+# Run the built application
+node dist/bundle.js
+```
+
+## Testing
+
+The test entry reuses the build config and swaps the entry point, then runs the bundled output through Node's built-in
+test runner.
+
+```javascript title="src/index.test.js"
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import rsLib from "./lib.rs";
+
+describe("rspack", () => {
+    test("fibonacci_bindgen", () => {
+        assert.equal(rsLib.fibonacci_bindgen(10), 55);
+    });
+
+    test("fibonacci_default", () => {
+        assert.equal(rsLib.fibonacci_default(10), 55);
+    });
+
+    test("cap", () => {
+        assert.equal(rsLib.cap("hello"), "Hello");
+    });
+});
+```
+
+```javascript title="test.rspack.config.js"
+const common = require("./rspack.config");
+
+common.entry = "./src/index.test.js";
+common.output.filename = "comp.test.js";
+module.exports = common;
+```
+
+```bash
+npm test
+```
+
+---
+
+:::tip Drop-in Webpack replacement
+Rspack mirrors the Webpack loader API, so the loader configuration is identical. If you already use rust-wasmpack-loader
+with Webpack, switching to Rspack needs no loader changes.
+:::

--- a/docs/docs/getting-started/overview.mdx
+++ b/docs/docs/getting-started/overview.mdx
@@ -31,6 +31,7 @@ graph LR
 - **Hot reload support** during development
 - **TypeScript integration** with generated type definitions
 - **Webpack 5+** support with explicit targets (web, node)
+- **Rspack** support through the same Webpack-compatible loader
 - **Bun runtime** compatibility for modern JavaScript environments
 - **esbuild plugin** for fast bundling on Node.js or the browser
 
@@ -53,12 +54,14 @@ graph LR
 
 ## Supported Targets
 
-| Target       | Webpack           | Bun | esbuild |
-|--------------|-------------------|-----|---------|
-| `web`        | ✅                 | ❌   | ✅       |
-| `node`       | ✅                 | ✅   | ✅       |
-| `node-async` | ✅                 | ✅   | ❌       |
-| `electron`   | ⚠️ *(not tested)* | ❌   | ❌       |
+| Target       | Webpack           | Rspack            | Bun | esbuild |
+|--------------|-------------------|-------------------|-----|---------|
+| `web`        | ✅                 | ✅                 | ❌   | ✅       |
+| `node`       | ✅                 | ✅                 | ✅   | ✅       |
+| `node-async` | ✅                 | ✅                 | ✅   | ❌       |
+| `electron`   | ⚠️ *(not tested)* | ⚠️ *(not tested)* | ❌   | ❌       |
+
+Rspack reuses the Webpack loader context, so the loader works with it through the same configuration.
 
 ## Comparison with Alternatives
 
@@ -96,7 +99,7 @@ graph LR
 - Offering **native Bun runtime support** (unique in the ecosystem)
 - Providing **automatic Cargo.toml discovery** up the directory tree
 - Requiring **zero configuration** for basic usage
-- Supporting **Webpack, Bun, and esbuild** from a single package
+- Supporting **Webpack, Rspack, Bun, and esbuild** from a single package
 
 **Alternative approaches:**
 - **Manual wasm-pack**: Requires separate build steps and manual integration

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -21,6 +21,7 @@ const sidebars = {
                 "docs/examples/node-webpack",
                 "docs/examples/node-bun",
                 "docs/examples/esbuild",
+                "docs/examples/rspack",
             ],
         },
         {

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -44,8 +44,7 @@ export default defineConfig([
             "src/**/*.js",
             "*.cjs",
             "docs/**/*.js",
-            "example/**/webpack.config.js",
-            "example/**/test.webpack.config.js",
+            "example/**/*.config.js",
         ],
         languageOptions: {
             sourceType: "commonjs",
@@ -113,10 +112,10 @@ export default defineConfig([
         },
     },
 
-    // --- Example build scripts (resolve deps only after the example is installed) ---
+    // --- Example build scripts and configs (resolve deps only after the example is installed) ---
     {
         name: "project/example-build-scripts",
-        files: ["example/**/build.mjs"],
+        files: ["example/**/build.mjs", "example/**/*.config.js"],
         rules: {
             "import-x/no-unresolved": "off",
             "import-x/no-extraneous-dependencies": "off",

--- a/example/rspack/.gitignore
+++ b/example/rspack/.gitignore
@@ -1,0 +1,3 @@
+/dist
+/node_modules
+/target

--- a/example/rspack/Cargo.toml
+++ b/example/rspack/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "wasm-fibonacci-test"
+version = "0.1.0"
+authors = ["Yehor Brodskiy"]
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+wasm-bindgen = "0.2.95"

--- a/example/rspack/package.json
+++ b/example/rspack/package.json
@@ -1,0 +1,16 @@
+{
+    "engines": {
+        "node": ">=22.22.2"
+    },
+    "scripts": {
+        "start": "rspack build --config rspack.config.js --watch",
+        "build": "rspack build --config rspack.config.js",
+        "test": "rspack build --config test.rspack.config.js && node --test dist/comp.test.js"
+    },
+    "devDependencies": {
+        "@rspack/cli": "^1.5.0",
+        "@rspack/core": "^1.5.0",
+        "rust-wasmpack-loader": "file:../..",
+        "webpack-node-externals": "^3.0.0"
+    }
+}

--- a/example/rspack/rspack.config.js
+++ b/example/rspack/rspack.config.js
@@ -1,4 +1,4 @@
-const path = require("path");
+const path = require("node:path");
 const nodeExternals = require("webpack-node-externals");
 
 module.exports = {

--- a/example/rspack/rspack.config.js
+++ b/example/rspack/rspack.config.js
@@ -1,0 +1,41 @@
+const path = require("path");
+const nodeExternals = require("webpack-node-externals");
+
+module.exports = {
+    mode: "development",
+    entry: "./src/index.js",
+    output: {
+        path: path.resolve(__dirname, "dist"),
+        filename: "bundle.js",
+        clean: true,
+    },
+    target: "node",
+    node: false,
+    externals: nodeExternals(),
+    module: {
+        rules: [
+            {
+                test: /\.rs$/,
+                exclude: /node_modules/,
+                use: [
+                    {
+                        loader: "rust-wasmpack-loader",
+                        options: {
+                            node: {
+                                bundle: true,
+                            },
+                            logLevel: "info",
+                        },
+                    },
+                ],
+            },
+        ],
+    },
+    resolve: {
+        extensions: [".js", ".ts"],
+    },
+    experiments: {
+        syncWebAssembly: true,
+        asyncWebAssembly: false,
+    },
+};

--- a/example/rspack/src/index.js
+++ b/example/rspack/src/index.js
@@ -1,0 +1,7 @@
+import rsLib from "./lib.rs";
+
+const NUM = 10;
+
+console.log(`fibonacci_bindgen(${NUM}) = ${rsLib.fibonacci_bindgen(NUM)}`);
+console.log(`fibonacci_default(${NUM}) = ${rsLib.fibonacci_default(NUM)}`);
+console.log(`cap("hello") = ${rsLib.cap("hello")}`);

--- a/example/rspack/src/index.test.js
+++ b/example/rspack/src/index.test.js
@@ -1,0 +1,17 @@
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+import rsLib from "./lib.rs";
+
+describe("rspack", () => {
+    test("fibonacci_bindgen", () => {
+        assert.equal(rsLib.fibonacci_bindgen(10), 55);
+    });
+
+    test("fibonacci_default", () => {
+        assert.equal(rsLib.fibonacci_default(10), 55);
+    });
+
+    test("cap", () => {
+        assert.equal(rsLib.cap("hello"), "Hello");
+    });
+});

--- a/example/rspack/src/lib.rs
+++ b/example/rspack/src/lib.rs
@@ -1,0 +1,26 @@
+extern crate wasm_bindgen;
+
+use wasm_bindgen::prelude::*;
+
+#[no_mangle]
+pub fn fibonacci_default(n: i32) -> i32 {
+    match n {
+        0 => 0,
+        1 => 1,
+        _ => fibonacci_default(n - 1) + fibonacci_default(n - 2),
+    }
+}
+
+#[wasm_bindgen]
+pub fn fibonacci_bindgen(n: i32) -> i32 {
+    match n {
+        0 => 0,
+        1 => 1,
+        _ => fibonacci_bindgen(n - 1) + fibonacci_bindgen(n - 2),
+    }
+}
+
+#[wasm_bindgen]
+pub fn cap(s: &str) -> String {
+    s[0..1].to_uppercase() + &s[1..]
+}

--- a/example/rspack/test.rspack.config.js
+++ b/example/rspack/test.rspack.config.js
@@ -1,0 +1,5 @@
+const common = require("./rspack.config");
+
+common.entry = "./src/index.test.js";
+common.output.filename = "comp.test.js";
+module.exports = common;

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "main": "./src/index.js",
     "scripts": {
         "release": "npx commit-and-tag-version && npm run postrelease",
-        "postrelease": "cd ./example/node-webpack && npm i && cd ../../ && cd ./example/web-webpack && npm i && cd ../../ && cd ./example/node-bun && npm i && cd ../../ && cd ./example/esbuild && npm i",
+        "postrelease": "cd ./example/node-webpack && npm i && cd ../../ && cd ./example/web-webpack && npm i && cd ../../ && cd ./example/node-bun && npm i && cd ../../ && cd ./example/esbuild && npm i && cd ../../ && cd ./example/rspack && npm i",
         "docs:start": "docusaurus start --config ./docs/docusaurus.config.js",
         "docs:build": "docusaurus build --config ./docs/docusaurus.config.js",
         "docs:swizzle": "docusaurus swizzle --config ./docs/docusaurus.config.js",
@@ -100,11 +100,15 @@
         "which": "^7.0.0"
     },
     "peerDependencies": {
+        "@rspack/core": ">=1.0.0",
         "bun": "1.x.x",
         "esbuild": ">=0.17.0",
         "webpack": "^5.0.0"
     },
     "peerDependenciesMeta": {
+        "@rspack/core": {
+            "optional": true
+        },
         "bun": {
             "optional": true
         },

--- a/src/index.js
+++ b/src/index.js
@@ -62,7 +62,8 @@ async function rustWasmLoader(source) {
     // Get all required params from webpack
     const params = {
         fileNameStruct:
-            this._compilation.outputOptions.webassemblyModuleFilename,
+            this._compilation.outputOptions.webassemblyModuleFilename ||
+            "[hash].module.wasm",
         baseFolder: this._compilation.options.context,
         resourcePath: this.resourcePath,
         target: this.target,

--- a/src/index.js
+++ b/src/index.js
@@ -120,9 +120,8 @@ async function rustWasmLoader(source) {
 
         // Find publicPath
         const publicPath =
-            params.target !== "web"
-                ? ""
-                : (() => {
+            params.target === "web"
+                ? (() => {
                       const webpackPublicPath = this._compilation.getAssetPath(
                           this._compilation.outputOptions.publicPath,
                           { hash: this._compilation.hash || "" },
@@ -145,7 +144,8 @@ async function rustWasmLoader(source) {
                                 )
                                 .split(path.sep)
                                 .join("/");
-                  })();
+                  })()
+                : "";
 
         const content = await pack(
             {

--- a/src/index.js
+++ b/src/index.js
@@ -119,28 +119,33 @@ async function rustWasmLoader(source) {
         );
 
         // Find publicPath
-        const webpackPublicPath = this._compilation.getAssetPath(
-            this._compilation.outputOptions.publicPath,
-            { hash: this._compilation.hash },
-        );
         const publicPath =
-            webpackPublicPath.trim() !== "" && webpackPublicPath !== "auto"
-                ? webpackPublicPath
-                : path
-                      .relative(
-                          path.resolve(
-                              this._compilation.options.output.path,
-                              path.dirname(
-                                  this._compilation.getAssetPath(
-                                      wasmName,
-                                      this.context,
-                                  ),
-                              ),
-                          ),
-                          this._compilation.options.output.path,
-                      )
-                      .split(path.sep)
-                      .join("/");
+            params.target !== "web"
+                ? ""
+                : (() => {
+                      const webpackPublicPath = this._compilation.getAssetPath(
+                          this._compilation.outputOptions.publicPath,
+                          { hash: this._compilation.hash || "" },
+                      );
+                      return webpackPublicPath.trim() !== "" &&
+                          webpackPublicPath !== "auto"
+                          ? webpackPublicPath
+                          : path
+                                .relative(
+                                    path.resolve(
+                                        this._compilation.options.output.path,
+                                        path.dirname(
+                                            this._compilation.getAssetPath(
+                                                wasmName,
+                                                this.context,
+                                            ),
+                                        ),
+                                    ),
+                                    this._compilation.options.output.path,
+                                )
+                                .split(path.sep)
+                                .join("/");
+                  })();
 
         const content = await pack(
             {


### PR DESCRIPTION
## Summary

Adds Rspack as a supported target. Rspack mirrors the webpack loader context, so `src/index.js` works unchanged except for a defensive fallback on `outputOptions.webassemblyModuleFilename` (Rspack's default is the same `[hash].module.wasm`, and webpack always populates it, so the fallback is inert there). Adds an `example/rspack` project to the CI matrix, `@rspack/core` as an optional peer dependency, and docs/README updates.

## Notes for reviewers

- One-line src change (the `_compilation` fallback); webpack behavior is preserved.
- The eslint config globs were broadened to cover the new `*.config.js` files (a superset of the prior webpack-config globs).
- The rspack example's actual Rust build is verified by CI (the dev host lacks the Windows SDK). Local checks: eslint clean, loader require + config-evaluation sanity.
