### PR TITLE
[RL-52] add option-driven target and import-based wasm delivery

### DIFF
--- a/docs/docs/api/index.md
+++ b/docs/docs/api/index.md
@@ -11,6 +11,9 @@ section documents all available options, their types, default values, and usage 
 
 ```typescript
 interface LoaderOptions {
+    // Override webpack's target ("web" or "node")
+    target?: "web" | "node";
+
     // Target-specific options
     web?: WebOptions;
     node?: NodeOptions;
@@ -25,13 +28,14 @@ interface LoaderOptions {
 
 ## Quick Reference
 
-| Option                 | Type       | Default  | Description               |
-|------------------------|------------|----------|---------------------------|
-| `web.asyncLoading`     | `boolean`  | `false`  | Enable async WASM loading |
-| `web.publicPath`       | `boolean`  | `true`   | Use webpack public path   |
-| `web.wasmPathModifier` | `string[]` | `["/"]`  | Modify WASM request path  |
-| `node.bundle`          | `boolean`  | `false`  | Bundle WASM in JS file    |
-| `logLevel`             | `string`   | `"info"` | Logging verbosity         |
+| Option                 | Type       | Default        | Description                 |
+|------------------------|------------|----------------|-----------------------------|
+| `target`               | `string`   | webpack target | Override the build target   |
+| `web.asyncLoading`     | `boolean`  | `false`        | Enable async WASM loading   |
+| `web.publicPath`       | `boolean`  | `true`         | Use webpack public path     |
+| `web.wasmPathModifier` | `string[]` | `["/"]`        | Modify WASM request path    |
+| `node.bundle`          | `boolean`  | `false`        | Bundle WASM in JS file      |
+| `logLevel`             | `string`   | `"info"`       | Logging verbosity           |
 
 ## Target Environments
 
@@ -126,9 +130,10 @@ plugin(loader.bun({
 
 #### Global Options
 
-| Option     | Type                                                  | Default  | Description               |
-|------------|-------------------------------------------------------|----------|---------------------------|
-| `logLevel` | `"verbose" \| "info" \| "warn" \| "error" \| "quiet"` | `"info"` | Control logging verbosity |
+| Option     | Type                                                  | Default          | Description                    |
+|------------|-------------------------------------------------------|------------------|--------------------------------|
+| `target`   | `"web" \| "node"`                                     | webpack `target` | Override the build target      |
+| `logLevel` | `"verbose" \| "info" \| "warn" \| "error" \| "quiet"` | `"info"`         | Control logging verbosity      |
 
 ### Bun Options
 
@@ -137,6 +142,27 @@ plugin(loader.bun({
 | `logLevel` | `"verbose" \| "info" \| "warn" \| "error" \| "quiet"` | `"info"` | Control logging verbosity |
 
 ## Detailed Option Reference
+
+### `target`
+
+**Type:** `"web" | "node"`  
+**Default:** webpack's `target`  
+**Target:** Webpack
+
+Overrides the build target the loader derives from webpack's own `target`. Set it
+when webpack's target does not map cleanly to `web` or `node`, or when a single
+config compiles `.rs` files for a different environment than the rest of the build.
+When omitted, the loader uses webpack's `target` as before.
+
+```javascript
+{
+    // Force the node build strategy regardless of webpack's target
+    target: "node",
+    node: {
+        bundle: true
+    }
+}
+```
 
 ### `web.asyncLoading`
 

--- a/src/index.js
+++ b/src/index.js
@@ -43,6 +43,12 @@ const optionsSchema = {
             },
             additionalProperties: false,
         },
+        target: {
+            type: "string",
+            enum: ["web", "node"],
+            description:
+                "Build target (`web` or `node`). Overrides webpack's `target` when set.",
+        },
         logLevel: {
             type: "string",
             description:
@@ -67,16 +73,9 @@ async function rustWasmLoader(source) {
             "[hash].module.wasm",
         baseFolder: this._compilation.options.context,
         resourcePath: this.resourcePath,
-        target: this.target,
     };
 
     try {
-        if (constants.supportedTargets.indexOf(params.target) === -1) {
-            throw new Error(
-                `patch is not presented for this target (${params.target}). Please, create new Issue or check the documentation.`,
-            );
-        }
-
         const options = merge(
             {
                 web: {
@@ -95,6 +94,15 @@ async function rustWasmLoader(source) {
         schemaUtils.validate(optionsSchema, options, {
             name: "rust-wasmpack-loader",
         });
+
+        // Loader option wins; fall back to webpack's own target.
+        params.target = options.target ?? this.target;
+
+        if (constants.supportedTargets.indexOf(params.target) === -1) {
+            throw new Error(
+                `patch is not presented for this target (${params.target}). Please, create new Issue or check the documentation.`,
+            );
+        }
 
         const { base } = path.parse(path.normalize(params.resourcePath));
 
@@ -119,9 +127,11 @@ async function rustWasmLoader(source) {
             },
         );
 
-        // Find publicPath
+        // Resolve publicPath only for the web path that actually fetches the
+        // emitted asset at runtime; every other delivery slices it off, so it
+        // stays empty and we avoid dereferencing compilation internals.
         const publicPath =
-            params.target === "web"
+            params.target === "web" && options.web.asyncLoading
                 ? (() => {
                       const webpackPublicPath = this._compilation.getAssetPath(
                           this._compilation.outputOptions.publicPath,

--- a/src/pack.js
+++ b/src/pack.js
@@ -32,6 +32,12 @@ function logLevelSelector(level) {
  * @property {boolean} bundle - bundle the wasm file
  */
 
+/** @typedef {Object} ImportOptions
+ * @property {string} urlExpression - JS expression that resolves to the wasm URL at runtime
+ * @property {"fetch" | "fs"} strategy - how the URL is consumed (fetch for web, fs for node/SSR)
+ * @property {string} [preamble] - source prepended to the module (e.g. a `import url from "./x.wasm?url"` line)
+ */
+
 /** @typedef {Object} Options
  * @property {string} resourcePath - path to the resource
  * @property {string} baseFolder - path to the base folder
@@ -41,7 +47,29 @@ function logLevelSelector(level) {
  * @property {string} logLevel - log level of the build
  * @property {WebOptions} web - web options
  * @property {NodeOptions} node - node options
+ * @property {ImportOptions} [import] - opt-in import-based wasm delivery (host bundler supplies the URL)
  * */
+
+// Shared default-export body: spreads the named Rust exports over any remaining
+// `wasm` bindings. Identical across every delivery so the module shape matches.
+const exportGenExpr = `{...exportedFunctions, ...Object.entries(wasm).filter(([item]) => Object.keys(exportedFunctions).indexOf(item) === -1).reduce((acc, item) => ({...acc,[item[0]]: item[1]}), {})}`;
+
+// Resolves the explicit wasm-delivery strategy from the loader params. The three
+// legacy values (fetch / inline / fsread) preserve the original target+option
+// branching exactly; `import` is opt-in and only chosen when `params.import` is set.
+function selectDelivery(params) {
+    if (params.import) {
+        return "import";
+    }
+    if (params.target === "web") {
+        return params.web.asyncLoading ? "fetch" : "inline";
+    }
+    return params.node.bundle ? "inline" : "fsread";
+}
+
+// Deliveries that emit the .wasm as a standalone asset (the host reads it at
+// runtime). inline/import keep everything in the JS, so they emit nothing.
+const assetEmittingDeliveries = new Set(["fetch", "fsread"]);
 
 /**
  * pack function
@@ -55,6 +83,10 @@ module.exports = async function pack(params, emitFile) {
 
     // Set wasm build folder
     const wasmBuildSource = path.join(params.buildFolder, "pkg");
+
+    // Pick the explicit delivery strategy up front so the emit decision and the
+    // post-processing branch read from one source of truth.
+    const delivery = selectDelivery(params);
 
     // Find the nearest Cargo.toml file
     const cargoData = findNearestCargoBy(constants)(
@@ -95,10 +127,7 @@ module.exports = async function pack(params, emitFile) {
     });
 
     // Add generated .wasm binary to webpack files
-    if (
-        (params.target === "web" && params.web.asyncLoading) ||
-        (params.target === "node" && !params.node.bundle)
-    ) {
+    if (assetEmittingDeliveries.has(delivery)) {
         emitFile(
             params.wasmName,
             fs.readFileSync(path.join(wasmBuildSource, params.wasmName)),
@@ -197,6 +226,63 @@ module.exports = async function pack(params, emitFile) {
                 }`,
             ].join("\n")}`;
         },
+
+        // Import-based delivery: the host bundler (Rollup/Vite/esbuild) resolves the
+        // .wasm as an asset and hands us its URL. We strip the wasm-pack bootstrap
+        // like the other modes and init from `params.import.urlExpression`.
+        import: (generatedJs) => {
+            const { urlExpression, strategy, preamble } = params.import;
+            const lines = generatedJs.replaceAll("_bg.wasm", "").split("\n");
+            const exportedFunctions = `const exportedFunctions = {${lines
+                .filter(
+                    (item) => !!item.match(/export function .+ {$/g)?.length,
+                )
+                .map((item) => item.split("function")[1].split("(")[0])
+                .map((item) => `${item}:${item}`)
+                .join(",")}};`;
+            // `fetch` reuses wasm-bindgen's own loader by feeding the URL into the
+            // existing `import.meta.url` input slot, then awaiting init() -> Promise
+            // default export (same shape as the web async path). `fs` strips the
+            // bootstrap and inits synchronously from the URL read off disk.
+            const body =
+                strategy === "fetch"
+                    ? (() => {
+                          const badImportIndex = lines.findIndex(
+                              (item) =>
+                                  !!item.match(/import.meta.url/g)?.length,
+                          );
+                          lines[badImportIndex] =
+                              `       input = ${urlExpression}`;
+                          return [
+                              ...lines.slice(
+                                  0,
+                                  lines.findIndex(
+                                      (item) =>
+                                          !!item.match(/export { initSync }/g)
+                                              ?.length,
+                                  ),
+                              ),
+                              exportedFunctions,
+                              `export default new Promise(async (resolve, reject)=> { try{await init(); resolve(${exportGenExpr})}catch(e){reject(e)}})`,
+                          ];
+                      })()
+                    : [
+                          ...lines.slice(
+                              0,
+                              lines.findIndex(
+                                  (item) =>
+                                      !!item.match(
+                                          /async function __wbg_init\(module_or_path\) {/g,
+                                      )?.length,
+                              ),
+                          ),
+                          `const __wbg_init = {}`,
+                          `initSync({module:require('fs').readFileSync(${urlExpression})});`,
+                          exportedFunctions,
+                          `export default ${exportGenExpr}`,
+                      ];
+            return `${[...(preamble ? [preamble] : []), ...body].join("\n")}`;
+        },
     };
 
     // read generated .js file
@@ -210,5 +296,7 @@ module.exports = async function pack(params, emitFile) {
         },
     );
 
-    return patch[params.target](generatedJs);
+    return delivery === "import"
+        ? patch.import(generatedJs)
+        : patch[params.target](generatedJs);
 };


### PR DESCRIPTION
## Summary

Refactors the shared engine so future bundler integrations can pick their target and wasm-delivery shape explicitly, without changing existing behavior.

- `src/index.js`: adds an optional `target` loader option (`web` | `node`) that overrides webpack''s own `target`; resolution falls back to `this.target` when unset. `this._compilation`/publicPath internals are now only dereferenced on the one delivery that consumes them (web + `asyncLoading`).
- `src/pack.js`: replaces the implicit target+option branching with an explicit delivery selection (`fetch` / `inline` / `fsread`) and adds an additive `import` delivery that inits from a host-bundler-supplied wasm URL (`fetch` for web, `fs` for node/SSR). The legacy `patch.web` / `patch.node` string bodies are untouched.
- Docs: documents the new `target` option only.

Existing Webpack and Bun output is byte-identical; the `import` delivery is unconsumed by any plugin in this PR.

## Notes for reviewers

- This host has no Rust toolchain, so the example matrix in CI is the only end-to-end regression gate. The existing-path output was checked for byte-identity via a stubbed harness; the new `import` delivery is exercised by its first consumer in RL-56 (Vite).
- The `import` delivery is intentionally additive (only selected when `params.import` is set), so it cannot affect the Webpack/Bun/esbuild/Rollup paths shipped today.