### PR TITLE
[RL-61] refactor the documentation for consistent voice and tighter structure

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,18 +1,17 @@
 # Contributing
 
-Thanks for considering contributing to rustwasm-loader!
+Thanks for contributing to rustwasm-loader.
 
 ## Opening issues
 
-If you find a bug, please feel free to [open an issue](https://github.com/yeskiy/rustwasm-loader/issues).
-
-If you're taking the time to mention a problem, even a seemingly minor one, it is greatly appreciated, and a totally valid contribution to this project. Thank you!
+Found a bug? [Open an issue](https://github.com/yeskiy/rustwasm-loader/issues). Reporting a problem, even a small one, is
+a real contribution and is appreciated.
 
 ## Fixing bugs
 
-We love pull requests. Here’s a quick guide:
+Pull requests are welcome. Here is the workflow:
 
-1. [Fork this repository](https://github.com/yeskiy/rustwasm-loader/fork) and then clone it locally:
+1. [Fork this repository](https://github.com/yeskiy/rustwasm-loader/fork), then clone it locally:
 
   ```bash
   git clone https://github.com/yeskiy/rustwasm-loader
@@ -23,7 +22,8 @@ We love pull requests. Here’s a quick guide:
   ```bash
   git checkout -b fix-for-that-thing
   ```
-3. Commit a failing test for the bug:
+
+3. Commit a failing test that demonstrates the bug:
 
   ```bash
   git commit -am "Adds a failing test to demonstrate that thing"
@@ -35,17 +35,15 @@ We love pull requests. Here’s a quick guide:
   git commit -am "Adds a fix for that thing!"
   ```
 
-5. If everything looks good, push to your fork:
+5. Push to your fork:
 
   ```bash
   git push origin fix-for-that-thing
   ```
 
-7. [Submit a pull request.](https://help.github.com/articles/creating-a-pull-request)
-
-8. Enjoy being the wonderful person you are
-
+6. [Open a pull request.](https://help.github.com/articles/creating-a-pull-request)
 
 ## Adding new features
 
-Thinking of adding a new feature? Cool! [Open an issue](https://github.com/yeskiy/rustwasm-loader/issues) and let’s design it together.
+Planning a new feature? [Open an issue](https://github.com/yeskiy/rustwasm-loader/issues) first so we can design it
+together.

--- a/README.md
+++ b/README.md
@@ -4,52 +4,35 @@
 [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=yeskiy_rustwasm-loader&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=yeskiy_rustwasm-loader)
 [![Known Vulnerabilities](https://snyk.io/test/github/yeskiy/rustwasm-loader/badge.svg)](https://snyk.io/test/github/yeskiy/rustwasm-loader)
 
-# Welcome to rust-wasmpack-loader
+# rust-wasmpack-loader
 
-**rust-wasmpack-loader** is a powerful Webpack and Bun loader that enables seamless integration of Rust resources into
-your JavaScript/TypeScript projects through WebAssembly (WASM).
+rust-wasmpack-loader compiles `.rs` (Rust) files to WebAssembly at build time and gives you back JavaScript that exposes
+the Rust exports. You import a `.rs` file the way you would import any module, and the loader handles the wasm-pack
+compilation and the glue code.
 
-## What is rust-wasmpack-loader?
+## Supported build tools
 
-rust-wasmpack-loader is a native WASM loader for `.rs` (Rust) resources that works with:
+- [Webpack](https://webpack.js.org/) `^5.0.0` (`web` and `node`/`node-async` targets)
+- [Rspack](https://rspack.rs/) `>=1.0.0` (the same Webpack-compatible loader, `web` and `node` targets)
+- [Bun](https://bun.sh/) runtime (`node` target only)
+- [esbuild](https://esbuild.github.io/) plugin (`node` and `web` targets, WASM inlined)
+- [Rollup](https://rollupjs.org/) plugin (`node` and `web` targets, WASM inlined)
+- [Vite](https://vite.dev/) plugin (SSR uses the `node` strategy, the client uses `web`, with an emitted `.wasm` asset on
+  production builds)
+- [Next.js](https://nextjs.org/) App Router through the `withRustWasm` helper (one `.rs` works from Server and Client
+  Components; the `node` strategy on the server, `web` on the client, bytes inlined)
 
-- [**Webpack**](https://webpack.js.org/) `^5.0.0` (Both `web` and `node` (`node-async`) targets)
-- [**Rspack**](https://rspack.rs/) `>=1.0.0` (same Webpack-compatible loader, `web` and `node` targets)
-- [**Bun**](https://bun.sh/) runtime (node target only)
-- [**esbuild**](https://esbuild.github.io/) plugin (`node` and `web` targets, inline WASM)
-- [**Rollup**](https://rollupjs.org/) plugin (`node` and `web` targets, inline WASM)
-- [**Vite**](https://vite.dev/) plugin (SSR uses the `node` strategy, the client uses `web`, with an emitted `.wasm`
-  asset on production builds)
-- [**Next.js**](https://nextjs.org/) App Router via the `withRustWasm` helper (one `.rs` works from Server and Client
-  Components; `node` strategy for the server, `web` for the client, bytes inlined)
+## What it does
 
-## Key Features
+- Import `.rs` files directly in your JavaScript or TypeScript. There is no separate build step to wire up.
+- Works with `wasm_bindgen` exports and with plain functions.
+- Finds the nearest `Cargo.toml` by walking up from the `.rs` file, so you do not configure the crate path by hand.
+- Builds for `web` and `node` targets, and across the bundlers listed above.
 
-🚀 **Easy Integration** — Import `.rs` files directly in your `.js` or `.ts` files without any headache
+You write computation-heavy code in Rust, pull in crates from the Rust ecosystem, and call the result from JavaScript
+without managing a separate compile-and-link pipeline.
 
-🔧 **Flexible Configuration** — Supports both `wasm_bindgen` and regular functions
-
-📦 **Smart Discovery** — Dynamically finds the `Cargo.toml` file for building the WASM source
-
-🌐 **Multi-Target Webpack Support** — Works with `web` and `node` applications
-
-⚡ **Bun Compatible** — Full support for Bun runtime (node target only for now)
-
-📦 **esbuild Plugin** — First-class esbuild plugin for `node` and `web` builds
-
-📦 **Rollup Plugin** — First-class Rollup plugin for `node` and `web` builds
-
-📦 **Vite Plugin** — SSR and client builds from one `.rs` import (`node` strategy for the server, `web` for the client)
-
-📦 **Next.js Helper** — `withRustWasm` wraps your `next.config`; the same `.rs` works from Server and Client Components
-
-## Why Use rust-wasmpack-loader?
-
-- **Simplicity**: The most obvious one — No complex build setups, import and use
-- **Write computation-heavy code in Rust**: Leverage Rust's performance for CPU-intensive tasks
-- **Ecosystem**: Access the rich Rust ecosystem from your any projects
-
-## Quick Example
+## Quick example
 
 ```javascript
 // Import Rust code directly
@@ -74,56 +57,41 @@ pub fn fibonacci(n: u32) -> u32 {
 }
 ```
 
-## Getting Started
+## Getting started
 
-Ready to boost your projects with native WebAssembly support? Let us get started!
-
-👉 [Installation Guide](https://yeskiy.github.io/rustwasm-loader/docs/getting-started/installation)
-
-👉 [Quick Start Tutorial](https://yeskiy.github.io/rustwasm-loader/docs/getting-started/quick-start)
+- [Installation guide](https://yeskiy.github.io/rustwasm-loader/docs/getting-started/installation)
+- [Quick start tutorial](https://yeskiy.github.io/rustwasm-loader/docs/getting-started/quick-start)
 
 ## Examples
 
-[View Examples documentation](https://yeskiy.github.io/rustwasm-loader/docs/examples)
+[View the examples documentation](https://yeskiy.github.io/rustwasm-loader/docs/examples).
 
-Check the **[example](https://github.com/yeskiy/rustwasm-loader/tree/main/example)** folder in the repository for a
-better understanding of how the loader works with different setups:
+The [example](https://github.com/yeskiy/rustwasm-loader/tree/main/example) folder in the repository shows how the loader
+works across different setups:
 
-- **[Web Webpack](https://github.com/yeskiy/rustwasm-loader/tree/main/example/web-webpack)** - Browser applications
-- **[Node.js Webpack](https://github.com/yeskiy/rustwasm-loader/tree/main/example/node-webpack)** - Server-side
-  applications
-- **[Rspack](https://github.com/yeskiy/rustwasm-loader/tree/main/example/rspack)** - Fast Rust-based bundling with the
-  Webpack-compatible loader
-- **[Bun Node.js](https://github.com/yeskiy/rustwasm-loader/tree/main/example/node-bun)** - High-performance Bun runtime
-- **[esbuild](https://github.com/yeskiy/rustwasm-loader/tree/main/example/esbuild)** - Fast bundling for Node.js or the
-  browser
-- **[Rollup](https://github.com/yeskiy/rustwasm-loader/tree/main/example/rollup)** - Bundling for Node.js or the browser
-  using the Rollup plugin
-- **[Vite](https://github.com/yeskiy/rustwasm-loader/tree/main/example/vite)** - SSR and client builds using the Vite
-  plugin
-- **[Next.js](https://github.com/yeskiy/rustwasm-loader/tree/main/example/next)** - App Router with Server and Client
+- [Web Webpack](https://github.com/yeskiy/rustwasm-loader/tree/main/example/web-webpack) - browser applications
+- [Node.js Webpack](https://github.com/yeskiy/rustwasm-loader/tree/main/example/node-webpack) - server-side applications
+- [Rspack](https://github.com/yeskiy/rustwasm-loader/tree/main/example/rspack) - the Webpack-compatible loader on Rspack
+- [Bun Node.js](https://github.com/yeskiy/rustwasm-loader/tree/main/example/node-bun) - the Bun runtime
+- [esbuild](https://github.com/yeskiy/rustwasm-loader/tree/main/example/esbuild) - bundling for Node.js or the browser
+- [Rollup](https://github.com/yeskiy/rustwasm-loader/tree/main/example/rollup) - bundling for Node.js or the browser with
+  the Rollup plugin
+- [Vite](https://github.com/yeskiy/rustwasm-loader/tree/main/example/vite) - SSR and client builds with the Vite plugin
+- [Next.js](https://github.com/yeskiy/rustwasm-loader/tree/main/example/next) - App Router with Server and Client
   Components using the `withRustWasm` helper
 
 ## Contributing
 
-Contributions are always welcome!
-
-See [CONTRIBUTING.md](https://yeskiy.github.io/rustwasm-loader/contributing) for ways to get started.
-
-Please feel free to:
-
-- 🐛 Report bugs and issues
-- 💡 Suggest new features
-- 📖 Improve documentation
-- 🔧 Submit pull requests
+Contributions are welcome. See [CONTRIBUTING.md](https://yeskiy.github.io/rustwasm-loader/contributing) for how to get
+started. Bug reports, feature suggestions, documentation fixes, and pull requests all help.
 
 ## Acknowledgements
 
-Special thanks to the projects that inspired and helped make rust-wasmpack-loader possible:
+Thanks to the projects this one builds on:
 
-- [@wasm-tool/wasm-pack-plugin](https://github.com/wasm-tool/wasm-pack-plugin) - Original inspiration for WebAssembly
-  integration
-- [wasm-pack](https://github.com/rustwasm/wasm-pack) - The amazing tool that makes Rust-to-WASM compilation seamless
+- [@wasm-tool/wasm-pack-plugin](https://github.com/wasm-tool/wasm-pack-plugin) - the original inspiration for the
+  WebAssembly integration
+- [wasm-pack](https://github.com/rustwasm/wasm-pack) - the tool that handles the Rust-to-WASM compilation
 
 ## License
 
@@ -131,13 +99,9 @@ This project is licensed under the [MIT License](https://choosealicense.com/lice
 
 See the [LICENSE](https://github.com/yeskiy/rustwasm-loader/blob/main/LICENSE) file for details.
 
-## Community & Support
+## Community and support
 
-- 📚 [Documentation](https://yeskiy.github.io/rustwasm-loader/)
-- 🐛 [Report Issues](https://github.com/yeskiy/rustwasm-loader/issues)
-- 💬 [GitHub Discussions](https://github.com/yeskiy/rustwasm-loader/discussions)
-- 📦 [NPM Package](https://www.npmjs.com/package/rust-wasmpack-loader)
-
----
-
-*Built with ❤️ by [Yehor Brodskiy](https://github.com/yeskiy)*
+- [Documentation](https://yeskiy.github.io/rustwasm-loader/)
+- [Report issues](https://github.com/yeskiy/rustwasm-loader/issues)
+- [GitHub Discussions](https://github.com/yeskiy/rustwasm-loader/discussions)
+- [NPM package](https://www.npmjs.com/package/rust-wasmpack-loader)

--- a/docs/docs/api/index.md
+++ b/docs/docs/api/index.md
@@ -1,13 +1,9 @@
-# API Reference
+# API reference
 
-Complete reference for rust-wasmpack-loader configuration options, methods, and settings across different build tools.
+This page documents the configuration options for rust-wasmpack-loader across the supported build tools, with their
+types, defaults, and usage. The available options depend on your target environment and build tool.
 
-## Overview
-
-rust-wasmpack-loader provides different configuration options depending on your target environment and build tool. This
-section documents all available options, their types, default values, and usage examples.
-
-## Configuration Structure
+## Configuration structure
 
 ```typescript
 interface LoaderOptions {
@@ -26,7 +22,7 @@ interface LoaderOptions {
 }
 ```
 
-## Quick Reference
+## Quick reference
 
 | Option                 | Type       | Default        | Description                 |
 |------------------------|------------|----------------|-----------------------------|
@@ -37,11 +33,11 @@ interface LoaderOptions {
 | `node.bundle`          | `boolean`  | `false`        | Bundle WASM in JS file      |
 | `logLevel`             | `string`   | `"info"`       | Logging verbosity           |
 
-## Target Environments
+## Target environments
 
-### Web Target (Browser)
+### Web target (browser)
 
-Used for browser applications with Webpack:
+For browser applications with Webpack:
 
 ```javascript title="webpack.config.js"
 module.exports = {
@@ -67,9 +63,9 @@ module.exports = {
 };
 ```
 
-### Node Target (Server)
+### Node target (server)
 
-Used for Node.js applications with Webpack:
+For Node.js applications with Webpack:
 
 ```javascript title="webpack.config.js"
 module.exports = {
@@ -93,9 +89,9 @@ module.exports = {
 };
 ```
 
-### Bun Target
+### Bun target
 
-Used with Bun runtime:
+For the Bun runtime:
 
 ```toml title="bunfig.toml"
 preload = ["./node_modules/rust-wasmpack-loader/bun/preload.js"]
@@ -110,11 +106,11 @@ plugin(loader.bun({
 }));
 ```
 
-## Configuration Options by Build Tool
+## Configuration options by build tool
 
-### Webpack Options
+### Webpack options
 
-#### Web Target Options
+#### Web target options
 
 | Option                 | Type       | Default | Description                                       |
 |------------------------|------------|---------|---------------------------------------------------|
@@ -122,26 +118,26 @@ plugin(loader.bun({
 | `web.publicPath`       | `boolean`  | `true`  | Use webpack's public path for WASM files          |
 | `web.wasmPathModifier` | `string[]` | `["/"]` | Modify WASM request path if wrong publicPath used |
 
-#### Node Target Options
+#### Node target options
 
 | Option        | Type      | Default | Description                                          |
 |---------------|-----------|---------|------------------------------------------------------|
 | `node.bundle` | `boolean` | `false` | Bundle WASM file in JS file (no separate .wasm file) |
 
-#### Global Options
+#### Global options
 
 | Option     | Type                                                  | Default          | Description                    |
 |------------|-------------------------------------------------------|------------------|--------------------------------|
 | `target`   | `"web" \| "node"`                                     | webpack `target` | Override the build target      |
 | `logLevel` | `"verbose" \| "info" \| "warn" \| "error" \| "quiet"` | `"info"`         | Control logging verbosity      |
 
-### Bun Options
+### Bun options
 
 | Option     | Type                                                  | Default  | Description               |
 |------------|-------------------------------------------------------|----------|---------------------------|
 | `logLevel` | `"verbose" \| "info" \| "warn" \| "error" \| "quiet"` | `"info"` | Control logging verbosity |
 
-## Detailed Option Reference
+## Detailed option reference
 
 ### `target`
 
@@ -149,10 +145,9 @@ plugin(loader.bun({
 **Default:** webpack's `target`  
 **Target:** Webpack
 
-Overrides the build target the loader derives from webpack's own `target`. Set it
-when webpack's target does not map cleanly to `web` or `node`, or when a single
-config compiles `.rs` files for a different environment than the rest of the build.
-When omitted, the loader uses webpack's `target` as before.
+Overrides the build target the loader derives from webpack's own `target`. Set it when webpack's target does not map
+cleanly to `web` or `node`, or when a single config compiles `.rs` files for a different environment than the rest of the
+build. When omitted, the loader uses webpack's `target`.
 
 ```javascript
 {
@@ -188,10 +183,8 @@ Controls how WebAssembly modules are loaded in the browser.
 }
 ```
 
-**When to use:**
-
-- `false`: Faster initial execution, larger bundle size
-- `true`: Smaller initial bundle, slightly slower first load
+Set `false` for faster initial execution at the cost of a larger bundle. Set `true` for a smaller initial bundle and a
+slightly slower first load.
 
 ### `web.publicPath`
 
@@ -265,10 +258,8 @@ Whether to bundle the WASM file inside the JavaScript bundle.
 }
 ```
 
-**When to use:**
-
-- `false`: Smaller JS bundle, separate WASM file
-- `true`: Single file deployment, larger JS bundle
+Set `false` for a smaller JS bundle with a separate WASM file. Set `true` to deploy a single file at the cost of a larger
+JS bundle.
 
 ### `logLevel`
 
@@ -296,9 +287,9 @@ Controls the verbosity of loader output.
 }
 ```
 
-### Custom Type Declarations
+### Custom type declarations
 
-You can also create custom type declarations:
+You can declare the module type yourself to get typed exports:
 
 ```typescript title="src/types.d.ts"
 declare module "*.rs" {

--- a/docs/docs/examples/esbuild.md
+++ b/docs/docs/examples/esbuild.md
@@ -2,16 +2,16 @@
 sidebar_position: 4
 ---
 
-# esbuild Example
+# esbuild example
 
-This example demonstrates how to use rust-wasmpack-loader with [esbuild](https://esbuild.github.io/). esbuild is an
-extremely fast bundler, and the loader ships a first-class plugin so you can import `.rs` files directly from your build.
+This example shows how to use rust-wasmpack-loader with [esbuild](https://esbuild.github.io/). The loader ships an
+esbuild plugin, so you import `.rs` files directly from your build.
 
-The plugin inlines the compiled WebAssembly as bytes into the generated JavaScript, so no extra asset handling is needed.
+The plugin inlines the compiled WebAssembly as bytes into the generated JavaScript, so there is no extra asset to handle.
 It picks the build strategy from esbuild's `platform` option: `node` builds for Node.js, while `browser`, `neutral`, and
 the default target a browser-like environment.
 
-## Project Structure
+## Project structure
 
 ```
 esbuild-example/
@@ -24,9 +24,9 @@ esbuild-example/
 └── package.json         # Dependencies and scripts
 ```
 
-## Setup Instructions
+## Setup
 
-### 1. Initialize Project
+### 1. Initialize the project
 
 ```bash
 mkdir my-esbuild-wasm-app
@@ -34,7 +34,7 @@ cd my-esbuild-wasm-app
 npm init -y
 ```
 
-### 2. Install Dependencies
+### 2. Install dependencies
 
 ```bash
 npm install --save-dev rust-wasmpack-loader esbuild
@@ -55,7 +55,7 @@ crate-type = ["cdylib"]
 wasm-bindgen = "0.2.95"
 ```
 
-### 4. Create Rust Code
+### 4. Create the Rust code
 
 ```rust title="src/lib.rs"
 use wasm_bindgen::prelude::*;
@@ -75,7 +75,9 @@ pub fn greet(name: &str) -> String {
 }
 ```
 
-### 5. Create the Entry Point
+### 5. Create the entry point
+
+Import the `.rs` file like any other module and call its exports.
 
 ```javascript title="src/index.js"
 import wasmModule from "./lib.rs";
@@ -84,7 +86,7 @@ console.log(wasmModule.greet("esbuild Developer"));
 console.log(`fibonacci(10) = ${wasmModule.fibonacci(10)}`);
 ```
 
-### 6. Create the Build Script
+### 6. Create the build script
 
 ```javascript title="build.mjs"
 import * as esbuild from "esbuild";
@@ -101,10 +103,10 @@ await esbuild.build({
 });
 ```
 
-For browser output, set `platform: "browser"` (or leave it unset) - the plugin will build the web strategy and inline the
-WebAssembly into the bundle.
+For browser output, set `platform: "browser"` (or leave it unset). The plugin then builds the web strategy and inlines
+the WebAssembly into the bundle.
 
-### 7. Update Package.json
+### 7. Update package.json
 
 ```json title="package.json"
 {
@@ -118,7 +120,7 @@ WebAssembly into the bundle.
 }
 ```
 
-## Running the Example
+## Running the example
 
 ```bash
 # Build the bundle
@@ -128,7 +130,7 @@ npm run build
 npm start
 ```
 
-## Plugin Options
+## Plugin options
 
 The esbuild plugin accepts the same `logLevel` option as the other targets:
 
@@ -141,6 +143,6 @@ rustWasmLoader.esbuild({
 ---
 
 :::tip Inline delivery
-The esbuild plugin currently inlines the `.wasm` bytes into the generated JavaScript. This keeps configuration to zero -
-there is no separate asset to copy or serve. Separate-asset delivery may arrive as a later enhancement.
+The esbuild plugin currently inlines the `.wasm` bytes into the generated JavaScript, so there is no separate asset to
+copy or serve and no extra configuration. Separate-asset delivery may arrive as a later enhancement.
 :::

--- a/docs/docs/examples/index.md
+++ b/docs/docs/examples/index.md
@@ -1,24 +1,20 @@
-# Examples Overview
+# Examples overview
 
-This section provides comprehensive examples for using rust-wasmpack-loader with different build tools and targets. Each
-example includes complete setup instructions, configuration files, and working code samples.
+Each example here is a complete project: the setup steps, the config files, and working Rust and JavaScript you can run. Pick the one that matches your build tool.
 
-## Available Examples
+## Web applications
 
-### 🌐 Web Applications
+- [Web Webpack](./web-webpack) - browser applications using Webpack.
 
-- **[Web Webpack](./examples/web-webpack)** - Browser applications using Webpack
+## Backend and CLI applications
 
-### 🚀 Backend/CLI Applications
+- [Node.js Webpack](./node-webpack) - server-side applications using Webpack.
+- [Bun](./node-bun) - the Bun runtime, wired through a preload plugin.
+- [esbuild](./esbuild) - fast bundling for Node.js or the browser using the esbuild plugin.
+- [Rspack](./rspack) - Rust-based bundling with the Webpack-compatible loader, unchanged.
+- [Rollup](./rollup) - bundling for Node.js or the browser using the Rollup plugin.
+- [Vite](./vite) - SSR and client builds using the Vite plugin (the `node` strategy for the server, `web` for the client).
 
-- **[Node.js Webpack](./examples/node-webpack)** - Server-side applications using Webpack
-- **[⚡Bun](./examples/node-bun)** - High-performance applications using Bun runtime
-- **[esbuild](./examples/esbuild)** - Fast bundling for Node.js or the browser using esbuild
-- **[Rspack](./examples/rspack)** - Fast Rust-based bundling with the Webpack-compatible loader
-- **[Rollup](./examples/rollup)** - Bundling for Node.js or the browser using the Rollup plugin
-- **[Vite](./examples/vite)** - SSR and client builds with the Vite plugin (node strategy for the server, web for the client)
+## Full-stack frameworks
 
-### 🧩 Full-Stack Frameworks
-
-- **[Next.js](./examples/next)** - App Router with the `withRustWasm` helper; the same `.rs` works from Server and Client Components (node strategy for the server, web for the client), under both Turbopack and webpack
-
+- [Next.js](./next) - App Router with the `withRustWasm` helper. The same `.rs` works from Server and Client Components (the `node` strategy for the server, `web` for the client), under both Turbopack and webpack.

--- a/docs/docs/examples/next.md
+++ b/docs/docs/examples/next.md
@@ -2,10 +2,10 @@
 sidebar_position: 8
 ---
 
-# Next.js Example
+# Next.js example
 
 This example shows how to use rust-wasmpack-loader with [Next.js](https://nextjs.org/) (App Router). The loader ships a
-`withRustWasm` helper that wraps your `next.config`, wiring the loader in so you can import `.rs` files from both Server
+`withRustWasm` helper that wraps your `next.config` and wires the loader in, so you import `.rs` files from both Server
 and Client Components. The helper picks the `node` strategy for the server and the `web` strategy for the client, and
 inlines the WebAssembly bytes in both cases. The wrapped config works under both bundlers: webpack (`next build
 --webpack`) and Turbopack (`next build`, the Next.js 16 default). See [Turbopack](#turbopack) below for what differs.
@@ -70,7 +70,7 @@ inlined bytes. On the webpack pass the helper rejects an Edge `.rs` import with 
 [above](#edge-runtime-limitation)). Turbopack has no per-rule signal for the Edge environment, so there is no equivalent
 guard there; keep `.rs` imports out of Edge routes by adding `export const runtime = "nodejs"` to the route segment.
 
-## Project Structure
+## Project structure
 
 ```
 next-example/
@@ -87,16 +87,16 @@ next-example/
 └── package.json            # Dependencies and scripts
 ```
 
-## Setup Instructions
+## Setup
 
-### 1. Initialize Project
+### 1. Initialize the project
 
 ```bash
 npx create-next-app@latest my-next-wasm-app
 cd my-next-wasm-app
 ```
 
-### 2. Install Dependencies
+### 2. Install dependencies
 
 ```bash
 npm install --save-dev rust-wasmpack-loader
@@ -117,7 +117,7 @@ crate-type = ["cdylib"]
 wasm-bindgen = "0.2.95"
 ```
 
-### 4. Create Rust Code
+### 4. Create the Rust code
 
 ```rust title="lib.rs"
 use wasm_bindgen::prelude::*;
@@ -137,7 +137,7 @@ pub fn cap(s: &str) -> String {
 }
 ```
 
-### 5. Wrap the Next Config
+### 5. Wrap the Next config
 
 ```javascript title="next.config.mjs"
 import rustWasmLoader from "rust-wasmpack-loader";
@@ -172,7 +172,7 @@ export default function Result() {
 }
 ```
 
-### 8. Update Package.json
+### 8. Update package.json
 
 The default scripts build under Turbopack. To build with webpack instead, add `--webpack` to `dev` and `build`.
 
@@ -188,14 +188,14 @@ The default scripts build under Turbopack. To build with webpack instead, add `-
 }
 ```
 
-## Running the Example
+## Running the example
 
 ```bash
 # Build under Turbopack (the Next.js 16 default). Add --webpack to use webpack.
 npm run build
 ```
 
-## Helper Options
+## Helper options
 
 ```javascript
 rustWasmLoader.next(nextConfig, {

--- a/docs/docs/examples/node-bun.md
+++ b/docs/docs/examples/node-bun.md
@@ -1,9 +1,9 @@
-# Bun Node.js Example
+# Bun Node.js example
 
-This example demonstrates how to use rust-wasmpack-loader with Bun runtime. Bun provides ultra-fast JavaScript execution
-and simplified configuration, making it perfect for high-performance applications.
+This example shows how to use rust-wasmpack-loader with the Bun runtime. Bun loads `.rs` files through a preload plugin,
+so the setup stays small.
 
-## Project Structure
+## Project structure
 
 ```
 node-bun-example/
@@ -18,11 +18,9 @@ node-bun-example/
 └── README.md            # Project documentation
 ```
 
-## Setup Instructions
+## Setup
 
 ### 1. Install Bun
-
-First, install Bun runtime:
 
 ```bash
 # macOS/Linux
@@ -35,7 +33,7 @@ powershell -c "irm bun.sh/install.ps1 | iex"
 bun --version
 ```
 
-### 2. Initialize Project
+### 2. Initialize the project
 
 ```bash
 mkdir my-bun-wasm-app
@@ -43,7 +41,7 @@ cd my-bun-wasm-app
 bun init -y
 ```
 
-### 3. Install Dependencies
+### 3. Install dependencies
 
 ```bash
 # Install rust-wasmpack-loader
@@ -93,6 +91,8 @@ panic = "abort"
 
 ### 5. Configure Bun
 
+Register the preload plugin so Bun can resolve `.rs` imports.
+
 ```toml title="bunfig.toml"
 # Basic configuration
 preload = ["./node_modules/rust-wasmpack-loader/bun/preload.js"]
@@ -109,7 +109,7 @@ preload = ["./node_modules/rust-wasmpack-loader/bun/preload.js"]
 # bun = true
 ```
 
-### 6. Create Rust Code
+### 6. Create the Rust code
 
 ```rust title="src/lib.rs"
 use wasm_bindgen::prelude::*;
@@ -224,7 +224,9 @@ pub fn is_palindrome(text: &str) -> bool {
 }
 ```
 
-### 7. Create Bun Entry Point
+### 7. Create the Bun entry point
+
+Import the `.rs` file like any other module and call its exports.
 
 ```javascript title="src/index.js"
 import wasmModule from "./lib.rs";
@@ -306,7 +308,7 @@ if (import.meta.main) {
 }
 ```
 
-### 8. Create Test File
+### 8. Create the test file
 
 ```javascript title="tests/wasm.test.js"
 import { test, expect } from "bun:test";
@@ -413,7 +415,7 @@ test("should multiply array correctly", () => {
 });
 ```
 
-### 9. Update Package.json
+### 9. Update package.json
 
 ```json title="package.json"
 {
@@ -430,9 +432,9 @@ test("should multiply array correctly", () => {
 }
 ```
 
-## Running the Example
+## Running the example
 
-### Development Mode
+### Development
 
 ```bash
 # Run the application
@@ -445,7 +447,7 @@ bun dev
 bun --inspect src/index.js
 ```
 
-### Testing
+### Tests
 
 ```bash
 # Run all tests
@@ -461,7 +463,7 @@ bun test tests/wasm.test.js
 bun test --coverage
 ```
 
-### Production Build
+### Production build
 
 ```bash
 # Build for production
@@ -471,11 +473,11 @@ bun build
 bun dist/index.js
 ```
 
-## Advanced Configuration
+## Advanced configuration
 
-### Custom Loader Configuration
+### Custom loader configuration
 
-Create a custom initialization file:
+To pass options to the plugin, register it from your own preload file instead of pointing `bunfig.toml` at the shipped one:
 
 ```javascript title="bun-init.js"
 import { plugin } from "bun";
@@ -486,7 +488,8 @@ plugin(loader.bun({
     // Add custom options here
 }));
 ```
-And add it to your `bunfig.toml`:
+
+Then point `bunfig.toml` at it:
 
 ```toml title="bunfig.toml"
 preload = [
@@ -496,7 +499,6 @@ preload = [
 
 ---
 
-:::tip Bun Performance 🚀
-Bun can be 2-10x faster than Node.js for many workloads, and combined with Rust WebAssembly, provides exceptional
-performance!
+:::tip Bun performance
+Bun can be 2-10x faster than Node.js for many workloads. Pairing it with Rust WebAssembly keeps that speed for compute-heavy code.
 :::

--- a/docs/docs/examples/node-webpack.md
+++ b/docs/docs/examples/node-webpack.md
@@ -2,12 +2,12 @@
 sidebar_position: 3
 ---
 
-# Node.js Webpack Example
+# Node.js Webpack example
 
-This example demonstrates how to use rust-wasmpack-loader in a Node.js application with Webpack. Perfect for server-side
-applications, CLI tools, and backend services that need high-performance Rust code.
+This example shows how to use rust-wasmpack-loader in a Node.js application with Webpack. Use it for server-side
+applications, CLI tools, and backend services that call into Rust as WebAssembly.
 
-## Project Structure
+## Project structure
 
 ```
 node-webpack-example/
@@ -23,9 +23,9 @@ node-webpack-example/
 └── test.webpack.config.js # Test configuration
 ```
 
-## Setup Instructions
+## Setup
 
-### 1. Initialize Project
+### 1. Initialize the project
 
 ```bash
 mkdir my-node-wasm-app
@@ -33,7 +33,7 @@ cd my-node-wasm-app
 npm init -y
 ```
 
-### 2. Install Dependencies
+### 2. Install dependencies
 
 ```bash
 # Install rust-wasmpack-loader and webpack
@@ -162,7 +162,7 @@ module.exports = {
 };
 ```
 
-### 5. Create Test Configuration
+### 5. Create the test configuration
 
 ```javascript title="test.webpack.config.js"
 const path = require("path");
@@ -227,7 +227,7 @@ module.exports = {
 };
 ```
 
-### 6. Create Rust Code
+### 6. Create the Rust code
 
 ```rust title="src/lib.rs"
 use wasm_bindgen::prelude::*;
@@ -307,7 +307,9 @@ pub fn process_numbers(numbers: &[f64]) -> Vec<f64> {
 }
 ```
 
-### 7. Create Node.js Entry Point
+### 7. Create the Node.js entry point
+
+Import the `.rs` file like any other module and call its exports.
 
 ```javascript title="src/index.js"
 import module from "./lib.rs";
@@ -381,7 +383,7 @@ if (import.meta.url === `file://${process.argv[1]}`) {
 }
 ```
 
-### 8. Create Test File
+### 8. Create the test file
 
 ```javascript title="tests/wasm.test.js"
 import wasmModule from "../src/lib.rs";
@@ -442,7 +444,7 @@ describe("Rust WebAssembly Module", () => {
 });
 ```
 
-### 9. Update Package.json
+### 9. Update package.json
 
 ```json title="package.json"
 {
@@ -457,18 +459,18 @@ describe("Rust WebAssembly Module", () => {
 }
 ```
 
-## Running the Example
+## Running the example
 
-### Development Mode
+### Development
 
 ```bash
 # Start development with hot reload
 npm start
 
-# The application will rebuild automatically when files change
+# The build re-runs automatically when files change
 ```
 
-### Production Build
+### Production build
 
 ```bash
 # Build for production
@@ -478,7 +480,7 @@ npm run build
 node dist/bundle.js
 ```
 
-### Running Tests
+### Tests
 
 ```bash
 # Run all tests
@@ -490,6 +492,6 @@ npm run test -- --watch
 
 ---
 
-:::tip Server Performance 🚀
-Node.js + Rust WebAssembly can provide significant performance improvements for CPU-intensive server operations!
+:::tip Server performance
+For CPU-intensive server work, calling into Rust as WebAssembly can be considerably faster than the same logic in JavaScript.
 :::

--- a/docs/docs/examples/rollup.md
+++ b/docs/docs/examples/rollup.md
@@ -2,19 +2,18 @@
 sidebar_position: 6
 ---
 
-# Rollup Example
+# Rollup example
 
-This example demonstrates how to use rust-wasmpack-loader with [Rollup](https://rollupjs.org/). The loader ships a
-first-class Rollup plugin, so you can import `.rs` files directly from your bundle.
+This example shows how to use rust-wasmpack-loader with [Rollup](https://rollupjs.org/). The loader ships a Rollup
+plugin, so you import `.rs` files directly from your bundle.
 
-The plugin inlines the compiled WebAssembly as bytes into the generated JavaScript, so no extra asset handling is needed.
+The plugin inlines the compiled WebAssembly as bytes into the generated JavaScript, so there is no extra asset to handle.
 Rollup has no platform concept of its own, so you choose the build strategy through the plugin's `target` option: `web`
 (the default) or `node`. This example targets Node.js.
 
-Because [Vite](https://vite.dev/) plugins are a superset of Rollup plugins, the same plugin works inside a Vite
-config as well.
+Because [Vite](https://vite.dev/) plugins are a superset of Rollup plugins, the same plugin works inside a Vite config.
 
-## Project Structure
+## Project structure
 
 ```
 rollup-example/
@@ -28,9 +27,9 @@ rollup-example/
 └── package.json              # Dependencies and scripts
 ```
 
-## Setup Instructions
+## Setup
 
-### 1. Initialize Project
+### 1. Initialize the project
 
 ```bash
 mkdir my-rollup-wasm-app
@@ -38,7 +37,7 @@ cd my-rollup-wasm-app
 npm init -y
 ```
 
-### 2. Install Dependencies
+### 2. Install dependencies
 
 ```bash
 npm install --save-dev rust-wasmpack-loader rollup
@@ -59,7 +58,7 @@ crate-type = ["cdylib"]
 wasm-bindgen = "0.2.95"
 ```
 
-### 4. Create Rust Code
+### 4. Create the Rust code
 
 ```rust title="src/lib.rs"
 use wasm_bindgen::prelude::*;
@@ -79,7 +78,9 @@ pub fn greet(name: &str) -> String {
 }
 ```
 
-### 5. Create the Entry Point
+### 5. Create the entry point
+
+Import the `.rs` file like any other module and call its exports.
 
 ```javascript title="src/index.js"
 import wasmModule from "./lib.rs";
@@ -88,7 +89,7 @@ console.log(wasmModule.greet("Rollup Developer"));
 console.log(`fibonacci(10) = ${wasmModule.fibonacci(10)}`);
 ```
 
-### 6. Create the Rollup Config
+### 6. Create the Rollup config
 
 ```javascript title="rollup.config.mjs"
 import rustWasmLoader from "rust-wasmpack-loader";
@@ -104,10 +105,10 @@ export default {
 };
 ```
 
-For browser output, set `target: "web"` (the default) - the plugin will build the web strategy and inline the
+For browser output, set `target: "web"` (the default). The plugin then builds the web strategy and inlines the
 WebAssembly into the bundle.
 
-### 7. Update Package.json
+### 7. Update package.json
 
 ```json title="package.json"
 {
@@ -121,7 +122,7 @@ WebAssembly into the bundle.
 }
 ```
 
-## Running the Example
+## Running the example
 
 ```bash
 # Build the bundle
@@ -131,7 +132,7 @@ npm run build
 npm start
 ```
 
-## Plugin Options
+## Plugin options
 
 The Rollup plugin accepts a `target` (since Rollup has no platform of its own) plus the shared `logLevel` option:
 
@@ -142,7 +143,7 @@ rustWasmLoader.rollup({
 });
 ```
 
-## Using It with Vite
+## Using it with Vite
 
 Vite builds on Rollup, so this plugin works inside a Vite config. For Vite,
 prefer the dedicated `rustWasmLoader.vite` plugin: it picks the `node` strategy
@@ -162,6 +163,6 @@ export default defineConfig({
 ---
 
 :::tip Inline delivery
-The Rollup plugin currently inlines the `.wasm` bytes into the generated JavaScript. This keeps configuration to zero -
-there is no separate asset to copy or serve. Separate-asset delivery may arrive as a later enhancement.
+The Rollup plugin currently inlines the `.wasm` bytes into the generated JavaScript, so there is no separate asset to
+copy or serve and no extra configuration. Separate-asset delivery may arrive as a later enhancement.
 :::

--- a/docs/docs/examples/rspack.md
+++ b/docs/docs/examples/rspack.md
@@ -2,15 +2,15 @@
 sidebar_position: 5
 ---
 
-# Rspack Example
+# Rspack example
 
-This example demonstrates how to use rust-wasmpack-loader with [Rspack](https://rspack.rs/). Rspack is a fast Rust-based
-bundler that mirrors the Webpack API, so the same loader you use with Webpack works here without any changes.
+This example shows how to use rust-wasmpack-loader with [Rspack](https://rspack.rs/). Rspack mirrors the Webpack API, so
+the same loader you use with Webpack works here unchanged.
 
 Because Rspack reuses the Webpack loader context, you configure the `.rs` rule exactly as you would for Webpack. This
 example targets Node.js and inlines the compiled WebAssembly into the bundle via the `node.bundle` option.
 
-## Project Structure
+## Project structure
 
 ```
 rspack-example/
@@ -25,9 +25,9 @@ rspack-example/
 └── test.rspack.config.js     # Test configuration
 ```
 
-## Setup Instructions
+## Setup
 
-### 1. Initialize Project
+### 1. Initialize the project
 
 ```bash
 mkdir my-rspack-wasm-app
@@ -35,7 +35,7 @@ cd my-rspack-wasm-app
 npm init -y
 ```
 
-### 2. Install Dependencies
+### 2. Install dependencies
 
 ```bash
 npm install --save-dev rust-wasmpack-loader @rspack/core @rspack/cli webpack-node-externals
@@ -56,7 +56,7 @@ crate-type = ["cdylib"]
 wasm-bindgen = "0.2.95"
 ```
 
-### 4. Create Rust Code
+### 4. Create the Rust code
 
 ```rust title="src/lib.rs"
 use wasm_bindgen::prelude::*;
@@ -85,7 +85,9 @@ pub fn cap(s: &str) -> String {
 }
 ```
 
-### 5. Create the Entry Point
+### 5. Create the entry point
+
+Import the `.rs` file like any other module and call its exports.
 
 ```javascript title="src/index.js"
 import rsLib from "./lib.rs";
@@ -147,7 +149,7 @@ With `node.bundle` set to `true`, the WebAssembly bytes are inlined into the gen
 `webassembly/async` rule never has to handle a separate `.wasm` asset. That is why `asyncWebAssembly` is disabled and
 `syncWebAssembly` is enabled here.
 
-### 7. Update Package.json
+### 7. Update package.json
 
 ```json title="package.json"
 {
@@ -161,7 +163,7 @@ With `node.bundle` set to `true`, the WebAssembly bytes are inlined into the gen
 }
 ```
 
-## Running the Example
+## Running the example
 
 ```bash
 # Build the bundle
@@ -173,7 +175,7 @@ node dist/bundle.js
 
 ## Testing
 
-The test entry reuses the build config and swaps the entry point, then runs the bundled output through Node's built-in
+The test config reuses the build config and swaps the entry point, then runs the bundled output through Node's built-in
 test runner.
 
 ```javascript title="src/index.test.js"

--- a/docs/docs/examples/vite.md
+++ b/docs/docs/examples/vite.md
@@ -2,11 +2,11 @@
 sidebar_position: 7
 ---
 
-# Vite Example
+# Vite example
 
-This example demonstrates how to use rust-wasmpack-loader with [Vite](https://vite.dev/). The loader ships a
-first-class Vite plugin, so you can import `.rs` files directly and the plugin compiles each one to the strategy that
-matches where it runs: the `node` strategy for the server (SSR) and the `web` strategy for the client, automatically.
+This example shows how to use rust-wasmpack-loader with [Vite](https://vite.dev/). The loader ships a Vite plugin, so you
+import `.rs` files directly and the plugin compiles each one to the strategy that matches where it runs: the `node`
+strategy for the server (SSR) and the `web` strategy for the client, automatically.
 
 Because [Vite](https://vite.dev/) plugins are a superset of [Rollup](https://rollupjs.org/) plugins, the
 [Rollup plugin](./rollup) also works inside Vite with a single fixed `target`. The dedicated Vite plugin shown here adds
@@ -29,7 +29,7 @@ Everywhere else it inlines the bytes, which is always correct and needs no asset
 Server vs client is detected per module: the plugin reads `this.environment.config.consumer` on Vite 6+ and falls back
 to the `options.ssr` flag on Vite 5.
 
-## Project Structure
+## Project structure
 
 ```
 vite-example/
@@ -45,9 +45,9 @@ vite-example/
 └── package.json             # Dependencies and scripts
 ```
 
-## Setup Instructions
+## Setup
 
-### 1. Initialize Project
+### 1. Initialize the project
 
 ```bash
 mkdir my-vite-wasm-app
@@ -55,7 +55,7 @@ cd my-vite-wasm-app
 npm init -y
 ```
 
-### 2. Install Dependencies
+### 2. Install dependencies
 
 ```bash
 npm install --save-dev rust-wasmpack-loader vite
@@ -76,7 +76,7 @@ crate-type = ["cdylib"]
 wasm-bindgen = "0.2.95"
 ```
 
-### 4. Create Rust Code
+### 4. Create the Rust code
 
 ```rust title="src/lib.rs"
 use wasm_bindgen::prelude::*;
@@ -96,7 +96,7 @@ pub fn greet(name: &str) -> String {
 }
 ```
 
-### 5. Create the Entries
+### 5. Create the entries
 
 The same `.rs` import works in both entries; the plugin decides the strategy.
 
@@ -119,7 +119,7 @@ wasmModule.then((rs) => {
 });
 ```
 
-### 6. Create the Vite Config
+### 6. Create the Vite config
 
 ```javascript title="vite.config.mjs"
 import { defineConfig } from "vite";
@@ -135,7 +135,7 @@ export default defineConfig({
 });
 ```
 
-### 7. Update Package.json
+### 7. Update package.json
 
 ```json title="package.json"
 {
@@ -149,7 +149,7 @@ export default defineConfig({
 }
 ```
 
-## Running the Example
+## Running the example
 
 ```bash
 # Client production build (emits a separate .wasm asset)
@@ -159,7 +159,7 @@ npm run build
 npm run build:ssr
 ```
 
-## Plugin Options
+## Plugin options
 
 ```javascript
 rustWasmLoader.vite({

--- a/docs/docs/examples/web-webpack.md
+++ b/docs/docs/examples/web-webpack.md
@@ -1,9 +1,9 @@
-# Web Webpack Example
+# Web Webpack example
 
-This example demonstrates how to use rust-wasmpack-loader in a browser application with Webpack. It is perfect for
-client-side applications that need high-performance Rust code running in the browser.
+This example shows how to use rust-wasmpack-loader in a browser application with Webpack. Use it when you want Rust code
+running client-side as WebAssembly.
 
-## Project Structure
+## Project structure
 
 ```
 web-webpack-example/
@@ -18,9 +18,9 @@ web-webpack-example/
 └── index.html          # HTML template
 ```
 
-## Setup Instructions
+## Setup
 
-### 1. Initialize Project
+### 1. Initialize the project
 
 ```bash
 mkdir my-web-wasm-app
@@ -28,7 +28,7 @@ cd my-web-wasm-app
 npm init -y
 ```
 
-### 2. Install Dependencies
+### 2. Install dependencies
 
 ```bash
 # Install rust-wasmpack-loader and webpack
@@ -124,7 +124,7 @@ module.exports = {
 };
 ```
 
-### 5. Create Rust Code
+### 5. Create the Rust code
 
 ```rust title="src/lib.rs"
 use wasm_bindgen::prelude::*;
@@ -182,7 +182,9 @@ pub fn main() {
 }
 ```
 
-### 6. Create JavaScript Entry
+### 6. Create the JavaScript entry
+
+Import the `.rs` file like any other module and call its exports.
 
 ```javascript title="src/index.js"
 // Import the Rust module
@@ -230,7 +232,7 @@ console.log("Original image data:", Array.from(imageData));
 console.log("Processed image data:", Array.from(processedData));
 ```
 
-### 7. Create HTML Template
+### 7. Create the HTML template
 
 ```html title="src/index.html"
 <!DOCTYPE html>
@@ -266,7 +268,7 @@ console.log("Processed image data:", Array.from(processedData));
 </html>
 ```
 
-### 8. Update Package.json
+### 8. Update package.json
 
 ```json title="package.json"
 {
@@ -280,9 +282,9 @@ console.log("Processed image data:", Array.from(processedData));
 }
 ```
 
-## Running the Example
+## Running the example
 
-### Development Mode
+### Development
 
 ```bash
 # Start the development server
@@ -292,9 +294,9 @@ npm start
 npm run dev
 ```
 
-The application will be available at `http://localhost:9000` with hot reload enabled.
+The app runs at `http://localhost:9000` with hot reload enabled.
 
-### Production Build
+### Production build
 
 ```bash
 # Build for production
@@ -304,11 +306,11 @@ npm run build
 npx serve dist
 ```
 
-## Advanced Configuration
+## Advanced configuration
 
-### Async Loading
+### Async loading
 
-For better performance, enable async WASM loading:
+To fetch the wasm as a separate asset instead of inlining it, enable async loading:
 
 ```javascript title="webpack.config.js"
 module.exports = {
@@ -332,7 +334,7 @@ module.exports = {
 };
 ```
 
-### TypeScript Integration
+### TypeScript integration
 
 Create a `tsconfig.json`:
 
@@ -359,22 +361,20 @@ Create a `tsconfig.json`:
 
 ## Troubleshooting
 
-### Common Issues
+### The WASM module does not load
 
-**WASM module not loading:**
+- Check the browser console for errors.
+- Make sure `experiments.asyncWebAssembly` is enabled. See [Can I use WebAssembly](https://caniuse.com/wasm) for browser support.
+- Confirm the Rust build succeeded.
 
-- Check the browser console for errors
-- Ensure `experiments.asyncWebAssembly` is enabled (check [**can I use WebAssembly**](https://caniuse.com/wasm) for browser support)
-- Verify Rust compilation succeeded
+### The bundle is large
 
-**Large bundle size:**
-
-- Enable production mode optimizations
-- Use `asyncLoading: true`
-- Optimize Rust dependencies
+- Build in production mode.
+- Set `asyncLoading: true` so the wasm loads as a separate asset.
+- Trim your Rust dependencies.
 
 ---
 
-:::tip Performance Boost 🚀
-WebAssembly can provide 10-100x performance improvements for computationally intensive tasks compared to JavaScript!
+:::tip Performance
+For computationally intensive tasks, WebAssembly can run 10-100x faster than equivalent JavaScript.
 :::

--- a/docs/docs/getting-started/installation.mdx
+++ b/docs/docs/getting-started/installation.mdx
@@ -3,16 +3,17 @@ import TabItem from '@theme/TabItem';
 
 # Installation
 
-This guide will walk you through installing rust-wasmpack-loader.
+This guide walks you through installing rust-wasmpack-loader.
 
 ## Prerequisites
 
 :::tip
-Need help with prerequisites? Check our [Prerequisites Guide](./prerequisites) for detailed installation instructions.
+For toolchain setup, see the [Prerequisites Guide](./prerequisites).
 :::
 
-## Package Installation
-### Version Compatibility
+## Version compatibility
+
+Pick the loader version that matches your toolchain.
 
 | rust-wasmpack-loader | Webpack-node | Webpack-web | Bun   | Node.js   | Rust     |
 |----------------------|--------------|-------------|-------|-----------|----------|
@@ -22,10 +23,9 @@ Need help with prerequisites? Check our [Prerequisites Guide](./prerequisites) f
 | 1.x.x                | ^5.0.0       | ❌           | ❌     | >=16.0.0  | >=1.30.0 |
 | 0.x.x                | ⚠️           | ❌           | ❌     | >=14.0.0  | >=1.30.0 |
 
+## Install the package
 
-### Install as Dependency
-
-For production use, install rust-wasmpack-loader as a regular dependency:
+Install rust-wasmpack-loader with your package manager. Drop the dev flag if you need it as a regular dependency.
 
 <Tabs groupId="package-managers" queryString="current-pm">
     <TabItem value="npm" label="npm" default>
@@ -51,16 +51,16 @@ For production use, install rust-wasmpack-loader as a regular dependency:
     </TabItem>
 </Tabs>
 
-## Next Steps
+## Next steps
 
-Now that you have rust-wasmpack-loader installed:
+With the loader installed, here is where to go next:
 
-- 🚀 [Quick Start](./quick-start) - Create your first Rust-WASM project
-- 🛠️ [Examples](../examples/web-webpack) - Explore working examples
-- 📚 [API Reference](../api) - Learn about available options and configurations
+- [Quick Start](./quick-start) - create your first Rust-WASM project
+- [Examples](../examples/web-webpack) - working examples for each build tool
+- [API Reference](../api) - available options and configuration
 
 ---
 
 :::info
-**Need help?** Join our community discussions or report issues on [GitHub](https://github.com/yeskiy/rustwasm-loader).
+Questions or bugs? Open an issue on [GitHub](https://github.com/yeskiy/rustwasm-loader).
 :::

--- a/docs/docs/getting-started/overview.mdx
+++ b/docs/docs/getting-started/overview.mdx
@@ -2,17 +2,17 @@
 
 ## What is rust-wasmpack-loader?
 
-**rust-wasmpack-loader** is a native WebAssembly (WASM) loader that allows you to seamlessly integrate Rust code into your JavaScript and TypeScript projects by just importing `.rs` files inside other code.
+rust-wasmpack-loader is a WebAssembly loader that lets you import `.rs` files directly in JavaScript and TypeScript. You import a Rust file the same way you import any module, and the loader compiles it to WebAssembly behind the scenes.
 
-## How It Works
+## How it works
 
-The loader automatically:
+When you import a `.rs` file, the loader:
 
-1. **Detects** `.rs` files in your project
-2. **Finds** the corresponding `Cargo.toml` configuration
-3. **Compiles** Rust code to WebAssembly using `wasm-pack`
-4. **Generates** JavaScript bindings with `wasm-bindgen`
-5. **Integrates** the compiled WASM module into your bundle
+1. Detects the `.rs` file in your project
+2. Finds the nearest `Cargo.toml`
+3. Compiles the Rust code to WebAssembly with `wasm-pack`
+4. Generates JavaScript bindings with `wasm-bindgen`
+5. Wires the compiled module into your bundle
 
 ## Architecture
 
@@ -26,36 +26,39 @@ graph LR
     E --> F
 ```
 
-## Key Benefits
-- **Direct imports** - Use `.rs` files like any other import module
-- **Hot reload support** during development
-- **TypeScript integration** with generated type definitions
-- **Webpack 5+** support with explicit targets (web, node)
-- **Rspack** support through the same Webpack-compatible loader
-- **Bun runtime** compatibility for modern JavaScript environments
-- **esbuild plugin** for fast bundling on Node.js or the browser
-- **Rollup plugin** for Rollup-based build pipelines
-- **Vite plugin** with automatic SSR (`node`) and client (`web`) output from a single `.rs` import
-- **Next.js helper** (`withRustWasm`) so one `.rs` works from Server and Client Components (App Router)
+## Key benefits
 
-## Use Cases
+- Import `.rs` files like any other module, with no separate build step to wire up
+- Hot reload during development
+- TypeScript integration through generated type definitions
+- Webpack 5+ with explicit targets (web, node)
+- Rspack through the same Webpack-compatible loader
+- Bun runtime support
+- esbuild plugin for bundling on Node.js or the browser
+- Rollup plugin for Rollup-based pipelines
+- Vite plugin that produces SSR (`node`) and client (`web`) output from a single `.rs` import
+- Next.js helper (`withRustWasm`) so one `.rs` file works from Server and Client Components (App Router)
 
-### Ideal For:
-- **Mathematical computations** (cryptography, image processing, algorithms)
-- **Huge data processing** (parsing, transformation, validation)
-- **Game engines** and graphics programming
-- **Performance-critical libraries**
-- **Legacy C/C++ code migration** to the web
+## Use cases
 
-### Examples:
+The loader fits work where Rust earns its keep:
+
+- Mathematical computation (cryptography, image processing, algorithms)
+- Large-scale data processing (parsing, transformation, validation)
+- Game engines and graphics programming
+- Performance-critical libraries
+- Migrating existing C/C++ code to the web
+
+Concrete examples:
+
 - Image filters and manipulation
-- Cryptocurrency mining/validation *(please, don't do this at least inside browsers)*
-- Scientific simulations
-- Audio/video processing
+- Cryptocurrency mining or validation *(please don't do this in a browser)*
+- Scientific simulation
+- Audio and video processing
 - Machine learning inference
 - Compression algorithms
 
-## Supported Targets
+## Supported targets
 
 | Target       | Webpack           | Rspack            | Bun | esbuild | Rollup | Vite | Next.js |
 |--------------|-------------------|-------------------|-----|---------|--------|------|---------|
@@ -73,16 +76,17 @@ Turbopack; the asset-emitting modes need `emitFile`, which Turbopack does not ex
 both (Edge cannot instantiate wasm from inlined bytes); on the webpack pass an Edge `.rs` import is rejected with a clear
 build-time error.
 
-## Comparison with Alternatives
+## Comparison with alternatives
 
-### Legend:
-- ✅ **Full support** - Feature works out of the box
-- ⚠️ **Partial support** - Feature works with additional configuration
-- 🤚 **manual setup** - Feature requires manual steps to enable
-- ❌ **No support** - Feature is not available
-- 🟢 **Good** - Excellent experience
-- 🟡 **Medium** - Acceptable with some effort
-- 🔴 **Poor** - Significant challenges
+Legend:
+
+- ✅ Full support - works out of the box
+- ⚠️ Partial support - works with extra configuration
+- 🤚 Manual setup - needs manual steps to enable
+- ❌ No support - not available
+- 🟢 Good - smooth experience
+- 🟡 Medium - workable with some effort
+- 🔴 Poor - significant friction
 
 | Feature                       | rust-wasmpack-loader | Manual wasm-pack | @wasm-tool/wasm-pack-plugin | vite-plugin-wasm | Rollup WASM | esbuild WASM | Raw WASM imports |
 |-------------------------------|----------------------|------------------|-----------------------------|------------------|-------------|--------------|------------------|
@@ -102,19 +106,19 @@ build-time error.
 | **Learning curve**            | 🟢 Easy              | 🔴 Hard          | 🟡 Medium                   | 🟡 Medium        | 🟡 Medium   | 🟡 Medium    | 🔴 Hard          |
 | **Maintenance status**        | 🟢 Active            | 🟢 Active        | 🟡 Limited                  | 🟢 Active        | 🟢 Active   | 🟢 Active    | N/A              |
 
-### Key Differentiators:
+What sets rust-wasmpack-loader apart:
 
-**rust-wasmpack-loader** stands out by:
-- Being the only loader to support **direct `.rs` file imports** without build configuration
-- Offering **native Bun runtime support** (unique in the ecosystem)
-- Providing **automatic Cargo.toml discovery** up the directory tree
-- Requiring **zero configuration** for basic usage
-- Supporting **Webpack, Rspack, Bun, esbuild, Rollup, Vite, and Next.js** from a single package
-- Being the only one to compile the same `.rs` import to **SSR (`node`) and client (`web`) output in Vite** automatically
+- The only loader with direct `.rs` file imports and no build configuration
+- Native Bun runtime support, which no other option in this list provides
+- Automatic `Cargo.toml` discovery up the directory tree
+- Zero configuration for basic usage
+- One package covering Webpack, Rspack, Bun, esbuild, Rollup, Vite, and Next.js
+- The only one that compiles the same `.rs` import to SSR (`node`) and client (`web`) output in Vite automatically
 
-**Alternative approaches:**
-- **Manual wasm-pack**: Requires separate build steps and manual integration
-- **@wasm-tool/wasm-pack-plugin**: More mature, Webpack-only, less automated and requires explicit configuration
-- **vite-plugin-wasm**: Vite-specific, different ecosystem
-- **Rollup/esbuild WASM**: Require pre-compiled WASM files
-- **Raw WASM imports**: No build automation, manual TypeScript bindings
+How the alternatives compare:
+
+- Manual wasm-pack: separate build steps and manual integration
+- @wasm-tool/wasm-pack-plugin: more mature but Webpack-only, less automated, and needs explicit configuration
+- vite-plugin-wasm: Vite-specific, a different ecosystem
+- Rollup and esbuild WASM: expect pre-compiled WASM files
+- Raw WASM imports: no build automation, and you write the TypeScript bindings yourself

--- a/docs/docs/getting-started/prerequisites.mdx
+++ b/docs/docs/getting-started/prerequisites.mdx
@@ -3,21 +3,21 @@ import TabItem from '@theme/TabItem';
 
 # Prerequisites
 
-Before you can use rust-wasmpack-loader, you need to set up your development environment with the required tools and dependencies.
+Before you use rust-wasmpack-loader, set up your environment with the tools below.
 
-## System Requirements
+## System requirements
 
-### Operating Systems
-- **Windows** 10/11 (x64)
-- **macOS** 10.15+ (Intel/Apple Silicon)
-- **Linux** (Ubuntu 18.04+, CentOS 7+, or equivalent)
+### Operating systems
+- Windows 10/11 (x64)
+- macOS 10.15+ (Intel or Apple Silicon)
+- Linux (Ubuntu 18.04+, CentOS 7+, or equivalent)
 
-### Hardware Requirements
-- **RAM**: 4GB minimum, 8GB recommended
-- **Storage**: 2GB free space for tools and dependencies
-- **CPU**: Any modern x64 or ARM64 processor
+### Hardware
+- RAM: 4GB minimum, 8GB recommended
+- Storage: 2GB free for tools and dependencies
+- CPU: any modern x64 or ARM64 processor
 
-### Version Compatibility
+### Version compatibility
 
 | Tool    | Minimum Version | Recommended   |
 |---------|-----------------|---------------|
@@ -25,14 +25,14 @@ Before you can use rust-wasmpack-loader, you need to set up your development env
 | Rust    | 1.88.0          | latest stable |
 | npm     | 10.0.0          | Latest        |
 
-## Required Software
+## Required software
 
 ### 1. Node.js
 
-rust-wasmpack-loader requires Node.js version 22.22.2 or higher.
+rust-wasmpack-loader requires Node.js 22.22.2 or higher.
 
 :::tip Best Practice
-We recommend using [Volta](https://volta.sh/) for managing Node.js versions. Volta helps ensure consistent Node.js environments across development and CI/CD systems.
+Use [Volta](https://volta.sh/) to manage Node.js versions. It keeps the Node.js version consistent across development and CI.
 :::
 
 #### Installation
@@ -100,7 +100,7 @@ We recommend using [Volta](https://volta.sh/) for managing Node.js versions. Vol
     </TabItem>
 </Tabs>
 
-#### Verify Installation
+#### Verify installation
 
 ```bash
 node --version  # Should show v22.22.2 or higher
@@ -112,7 +112,7 @@ volta list  # Should show the installed Node.js version
 
 ### 2. Rust
 
-Rust is required to compile your `.rs` files to WebAssembly. Building `.rs` sources uses wasm-pack 0.15, which requires Rust 1.88.0 or higher.
+Rust compiles your `.rs` files to WebAssembly. The build uses wasm-pack 0.15, which requires Rust 1.88.0 or higher.
 
 #### Installation
 
@@ -145,7 +145,7 @@ Rust is required to compile your `.rs` files to WebAssembly. Building `.rs` sour
     </TabItem>
 </Tabs>
 
-#### Verify Installation
+#### Verify installation
 
 ```bash
 rustc --version    # Should show 1.88.0 or higher
@@ -153,6 +153,6 @@ cargo --version    # Should show 1.88.0 or higher
 ```
 ---
 
-:::tip Environment Ready! ✅
-Your development environment is now configured for Rust-WebAssembly development with rust-wasmpack-loader!
+:::tip
+Your environment is ready for Rust-WebAssembly development with rust-wasmpack-loader.
 :::

--- a/docs/docs/getting-started/quick-start.mdx
+++ b/docs/docs/getting-started/quick-start.mdx
@@ -1,11 +1,11 @@
 # Quick Start
 
-Get up and running with rust-wasmpack-loader in just a few minutes! This guide will walk you through creating your first Rust-WebAssembly project with **Webpack** in `web` target and **rust-wasmpack-loader**.
+This guide builds your first Rust-WebAssembly project with Webpack on the `web` target and rust-wasmpack-loader. It takes a few minutes.
 :::tip
-For other examples, check out our [Examples Section](../examples).
+For other setups, see the [Examples Section](../examples).
 :::
 
-## Step 1: Create a New Project
+## Step 1: Create a new project
 
 ```bash
 mkdir my-rust-wasm-app
@@ -13,7 +13,7 @@ cd my-rust-wasm-app
 npm init -y
 ```
 
-## Step 2: Install Dependencies
+## Step 2: Install dependencies
 
 ```bash
 # Install rust-wasmpack-loader
@@ -46,7 +46,7 @@ features = [
 ]
 ```
 
-## Step 4: Write Your First Rust Function
+## Step 4: Write your first Rust function
 
 Create a `src/lib.rs` file:
 
@@ -128,7 +128,7 @@ module.exports = {
 };
 ```
 
-## Step 6: Create JavaScript Entry Point
+## Step 6: Create the JavaScript entry point
 
 Create a `src/index.js` file:
 
@@ -156,7 +156,7 @@ document.body.innerHTML = `
 `;
 ```
 
-## Step 7: Create HTML File
+## Step 7: Create the HTML file
 
 Create a `dist/index.html` file:
 
@@ -174,7 +174,7 @@ Create a `dist/index.html` file:
 </html>
 ```
 
-## Step 8: Add Build Scripts
+## Step 8: Add build scripts
 
 Update your `package.json`:
 
@@ -190,7 +190,7 @@ Update your `package.json`:
 }
 ```
 
-## Step 9: Build and Run
+## Step 9: Build and run
 
 ```bash
 # Build the project
@@ -200,25 +200,25 @@ npm run build
 npm start
 ```
 
-Open your browser and navigate to `http://localhost:9000`. You should see:
+Open your browser at `http://localhost:9000`. You should see:
 
 - Fibonacci(10) = 55
 - 5 + 3 = 8
 - A greeting message in the console
 
-## What Just Happened?
+## What just happened
 
-1. **Rust Code**: You wrote Rust functions and exported them with `#[wasm_bindgen]`
-2. **Compilation**: rust-wasmpack-loader automatically compiled your Rust code to WebAssembly
-3. **Integration**: The loader generated JavaScript bindings for your Rust functions
-4. **Import**: You imported the `.rs` file directly in JavaScript
-5. **Execution**: Your Rust functions ran in the browser!
+1. Rust code: you wrote Rust functions and exported them with `#[wasm_bindgen]`
+2. Compilation: rust-wasmpack-loader compiled your Rust to WebAssembly
+3. Integration: the loader generated JavaScript bindings for your Rust functions
+4. Import: you imported the `.rs` file directly in JavaScript
+5. Execution: your Rust functions ran in the browser
 
-## Next Steps
+## Next steps
 
-### Advanced Configuration
+### Advanced configuration
 
-Customize the loader behavior:
+Customize the loader's behavior:
 
 ```javascript title="webpack.config.js"
 // In your webpack.config.js rules array
@@ -242,6 +242,6 @@ const rule = {
 
 ---
 
-:::tip Congratulations! 🎉
-You've successfully created your first Rust-WebAssembly application! The combination of Rust's performance and JavaScript's flexibility opens up endless possibilities.
+:::tip
+That is your first Rust-WebAssembly application. From here, explore the API options and the other build-tool examples.
 :::


### PR DESCRIPTION
## Summary

A writing pass over the full documentation set so the pages read as cohesive, natural technical writing with one consistent voice and a tighter structure.

- Rewrites the prose across the getting-started guides, every example page, the API reference, the README, and CONTRIBUTING.
- Headings are sentence-cased, padding and formulaic sections are cut, and the voice is consistent across all pages.
- Code samples, option tables, the `LoaderOptions` interface, version/compatibility tables, frontmatter, sidebar order, routes, and documented behavior are unchanged. No options, defaults, versions, or code changed.

## Notes for reviewers

- Also fixes the broken sibling links in the examples index (`./examples/web-webpack` resolved to a non-existent nested path; now `./web-webpack`, matching the sidebar and the other pages). `onBrokenLinks` is set to `warn`, so these were previously warnings rather than build failures.
- The two `.mdx` files that only `import` and render the README / CONTRIBUTING were left as-is; they pick up the rewrites through those imports.