### PR TITLE
[RL-66] Fix the broken example links on the Examples overview page

### DIFF
--- a/docs/docs/examples/index.md
+++ b/docs/docs/examples/index.md
@@ -4,21 +4,21 @@ Each example here is a complete project: the setup steps, the config files, and 
 
 ## Web applications
 
-- [Web Webpack](./web-webpack) - browser applications using Webpack.
+- [Web Webpack](./web-webpack.md) - browser applications using Webpack.
 
 ## Backend and CLI applications
 
-- [Node.js Webpack](./node-webpack) - server-side applications using Webpack.
-- [Bun](./node-bun) - the Bun runtime, wired through a preload plugin.
-- [esbuild](./esbuild) - fast bundling for Node.js or the browser using the esbuild plugin.
-- [Rspack](./rspack) - Rust-based bundling with the Webpack-compatible loader, unchanged.
-- [Rollup](./rollup) - bundling for Node.js or the browser using the Rollup plugin.
-- [Vite](./vite) - SSR and client builds using the Vite plugin (the `node` strategy for the server, `web` for the client).
+- [Node.js Webpack](./node-webpack.md) - server-side applications using Webpack.
+- [Bun](./node-bun.md) - the Bun runtime, wired through a preload plugin.
+- [esbuild](./esbuild.md) - fast bundling for Node.js or the browser using the esbuild plugin.
+- [Rspack](./rspack.md) - Rust-based bundling with the Webpack-compatible loader, unchanged.
+- [Rollup](./rollup.md) - bundling for Node.js or the browser using the Rollup plugin.
+- [Vite](./vite.md) - SSR and client builds using the Vite plugin (the `node` strategy for the server, `web` for the client).
 
 ## Full-stack frameworks
 
-- [Next.js](./next) - App Router with the `withRustWasm` helper. The same `.rs` works from Server Components, Client Components, and Edge routes (the `node` strategy for the server, `web` for the client, and a pre-compiled module on Edge), under both Turbopack and webpack.
+- [Next.js](./next.md) - App Router with the `withRustWasm` helper. The same `.rs` works from Server Components, Client Components, and Edge routes (the `node` strategy for the server, `web` for the client, and a pre-compiled module on Edge), under both Turbopack and webpack.
 
 ## Desktop applications
 
-- [Electron](./electron) - main and renderer processes with Webpack (`electron-main` uses the `node` strategy, `electron-renderer` uses `web`), with the wasm bytes inlined into both.
+- [Electron](./electron.md) - main and renderer processes with Webpack (`electron-main` uses the `node` strategy, `electron-renderer` uses `web`), with the wasm bytes inlined into both.


### PR DESCRIPTION
## What

The Examples overview page (`docs/docs/examples/index.md`) linked each example with a bare relative path (`./node-webpack`). With `trailingSlash: false`, the page is served at `/docs/examples`, so the browser resolved those links to `/docs/<name>` (a 404) instead of `/docs/examples/<name>`. `onBrokenLinks` is `warn`, so the build never flagged it.

## Fix

Give the doc-to-doc links their `.md` extension (`./node-webpack.md`). Docusaurus resolves those to the target document's absolute route at build time, so they land on `/docs/examples/<name>` regardless of the trailing-slash setting.

Only the Examples index was affected; the sibling links from deeper pages (`rollup.md`, `vite.md`) already resolve correctly because their extra path depth makes relative resolution land in `/docs/examples/`.

## Validation

Docs-only change. The Docusaurus build (and live deploy) runs on push to `main`, not on PRs, so the live links are verified post-merge. The `.md` link rewrite is deterministic Docusaurus behavior and every target file exists.